### PR TITLE
create ansible setting to start services at boot

### DIFF
--- a/deploy/ansible/README.md
+++ b/deploy/ansible/README.md
@@ -114,6 +114,7 @@ To setup KNIX on localhost, or a single remote host, or a cluster of hosts
 
 3. Update `settings.json`
     * `mfn_server_installation_folder`: folder where KNIX will be installed
+    * `start_at_boot`: whether KNIX services should be started at system start up
     * `riak_leveldb_maximum_memory`: total memory (in bytes) assigned to each Riak storage node's LevelDB backend
     * `nginx_http_listen_port`: http port the ngix server, serving the KNIX GUI, will listen on
     * `nginx_https_listen_port`: https port the ngix server, serving the KNIX GUI, will listen on

--- a/deploy/ansible/datalayer.yaml
+++ b/deploy/ansible/datalayer.yaml
@@ -89,12 +89,21 @@
         [Install]
         WantedBy=multi-user.target
 
-  - name: systemd start datalayer service
+  - name: systemd install and enable datalayer service
     systemd:
       daemon_reload: yes
       name: "{{ service_name }}"
       enabled: true
       state: restarted
+    when: start_at_boot|bool
+
+  - name: systemd install and disable datalayer service
+    systemd:
+      daemon_reload: yes
+      name: "{{ service_name }}"
+      enabled: false
+      state: stopped
+    when: not start_at_boot|bool
 
   - name: create start script
     copy:

--- a/deploy/ansible/elasticsearch.yaml
+++ b/deploy/ansible/elasticsearch.yaml
@@ -234,7 +234,7 @@
         [Service]
         OOMScoreAdjust=-1000
         LimitNOFILE=65536
-        LimitMEMLOCK=unlimited
+        LimitMEMLOCK=infinity
         Type=simple
         User=elasticsearch
         Group=elasticsearch
@@ -245,10 +245,14 @@
         [Install]
         WantedBy=multi-user.target
 
-  - name: systemd start mfn-elasticsearch
+  # regardless of start_at_boot setting, we install the script and start it
+  # because we have to perform some operations
+  # if start_at_boot is set to false, we'll disable it afterwards
+  - name: systemd install and start mfn-elasticsearch service to perform initialization operations
     systemd:
       daemon_reload: yes
       name: "{{ es_server_service_name }}"
+      enabled: true
       state: restarted
     become: yes
 
@@ -309,3 +313,12 @@
   - debug:
       var: esconfig_command.stdout
     when: ansible_default_ipv4.address == es_master_ip
+
+  - name: systemd install and disable mfn-elasticsearch service
+    systemd:
+      daemon_reload: yes
+      name: "{{ es_server_service_name }}"
+      enabled: false
+      state: stopped
+    become: yes
+    when: not start_at_boot|bool

--- a/deploy/ansible/fluentbit.yaml
+++ b/deploy/ansible/fluentbit.yaml
@@ -171,12 +171,21 @@
         [Install]
         WantedBy=multi-user.target
 
-  - name: systemd start fluent-bit service
+  - name: systemd install and enable fluent-bit service
     systemd:
       daemon_reload: yes
       name: "{{ service_name }}"
       enabled: true
       state: restarted
+    when: start_at_boot|bool
+
+  - name: systemd install and disable fluent-bit service
+    systemd:
+      daemon_reload: yes
+      name: "{{ service_name }}"
+      enabled: false
+      state: stopped
+    when: not start_at_boot|bool
 
   - name: create start script
     copy:

--- a/deploy/ansible/frontend.yaml
+++ b/deploy/ansible/frontend.yaml
@@ -146,11 +146,21 @@
         [Install]
         WantedBy=multi-user.target
 
-  - name: systemd start service mfn-frontend
+  - name: systemd install and enable service mfn-frontend
     systemd:
       daemon_reload: yes
       name: "{{ service_name }}"
+      enabled: true
       state: restarted
+    when: start_at_boot|bool
+
+  - name: systemd install and disable service mfn-frontend
+    systemd:
+      daemon_reload: yes
+      name: "{{ service_name }}"
+      enabled: false
+      state: stopped
+    when: not start_at_bool|bool
 
   - name: create frontend systemctl start script
     copy:

--- a/deploy/ansible/riak.yaml
+++ b/deploy/ansible/riak.yaml
@@ -302,10 +302,14 @@
         [Install]
         WantedBy=multi-user.target
 
-  - name: systemd restart mfn-riak
+  # regardless of start_at_boot setting, we install the script and start it
+  # because we have to perform some operations
+  # if start_at_boot is set to false, we'll disable it afterwards
+  - name: systemd install and enable mfn-riak service to perform initialization operations
     systemd:
       daemon_reload: yes
       name: "{{ riak_server_service_name }}"
+      enabled: true
       state: restarted
 
   - name: create riak start script
@@ -447,10 +451,24 @@
       msg:
         - "{{ wait_result1.stderr_lines[-1] }}"
         - "{{ wait_result2.stderr_lines[-1] }}"
+
 - hosts: riak
+  vars:
+    # riak service path on target machine
+    riak_server_service_name: mfn-riak
+    riak_server_service_path: "/lib/systemd/system/{{ riak_server_service_name }}.service"
+
   tasks:
   - name: create ring
     shell: |
       /usr/sbin/riak-admin cluster plan
       /usr/sbin/riak-admin cluster commit
     when: hostvars[groups['riak'][0]].ansible_default_ipv4.address == ansible_default_ipv4.address
+
+  - name: systemd install and disable mfn-riak service
+    systemd:
+      daemon_reload: yes
+      name: "{{ riak_server_service_name }}"
+      enabled: false
+      state: stopped
+    when: not start_at_boot|bool

--- a/deploy/ansible/settings.json
+++ b/deploy/ansible/settings.json
@@ -1,5 +1,6 @@
 {
     "mfn_server_installation_folder": "/opt/knix",
+    "start_at_boot": false,
     "riak_leveldb_maximum_memory": "4294967296",
     "nginx_http_listen_port": "80",
     "nginx_https_listen_port": "443",


### PR DESCRIPTION
This PR introduces a new ansible preference whether the installed components should be started at system startup. The default is set to `false`.

riak and elasticsearch components require some initialization; therefore, the service scripts are created and the services started, but at the end of the installation process, they are modified not to start at boot time.

Fixes #65.