### PR TITLE
patch riak k8s riak config to pass all riak replicas to the DLService

### DIFF
--- a/deploy/helm/microfunctions/templates/_helpers.tpl
+++ b/deploy/helm/microfunctions/templates/_helpers.tpl
@@ -25,7 +25,7 @@
 {{- define "rkConnect.url" }}
 {{- $port := index .Values "riak" "ClientPortProtobuf" | toString -}}
 {{- range $num, $e := until (.Values.riak.replicas|int) -}}
-    {{- printf "rk-%s-%d.%s.%s.svc:%d" $.Release.Name $num $.Release.Name $.Release.Namespace ($.Values.riak.ClientPortProtobuf|int) -}}
+    {{- printf "rk-%s-%d.rk-%s.%s.svc:%d" $.Release.Name $num $.Release.Name $.Release.Namespace ($.Values.riak.ClientPortProtobuf|int) -}}
     {{- if lt $num  ( sub ($.Values.riak.replicas|int) 1 ) -}}
       {{- printf "," -}}
     {{- end -}}

--- a/deploy/helm/microfunctions/templates/_helpers.tpl
+++ b/deploy/helm/microfunctions/templates/_helpers.tpl
@@ -25,7 +25,7 @@
 {{- define "rkConnect.url" }}
 {{- $port := index .Values "riak" "ClientPortProtobuf" | toString -}}
 {{- range $num, $e := until (.Values.riak.replicas|int) -}}
-    {{- printf "rk-%s-%d.%s.svc:%d" $.Release.Name $num $.Release.Namespace ($.Values.riak.ClientPortProtobuf|int) -}}
+    {{- printf "rk-%s-%d.%s.%s.svc:%d" $.Release.Name $num $.Release.Name $.Release.Namespace ($.Values.riak.ClientPortProtobuf|int) -}}
     {{- if lt $num  ( sub ($.Values.riak.replicas|int) 1 ) -}}
       {{- printf "," -}}
     {{- end -}}

--- a/deploy/helm/microfunctions/templates/_helpers.tpl
+++ b/deploy/helm/microfunctions/templates/_helpers.tpl
@@ -23,10 +23,13 @@
 {{- end -}}
 
 {{- define "rkConnect.url" }}
-{{- $rlsname := .Release.Name -}}
-{{- $namespace := .Release.Namespace -}}
 {{- $port := index .Values "riak" "ClientPortProtobuf" | toString -}}
-    rk-{{$rlsname}}.{{$namespace}}.svc:{{$port}}
+{{- range $num, $e := until (.Values.riak.replicas|int) -}}
+    {{- printf "rk-%s-%d.%s.svc:%d" $.Release.Name $num $.Release.Namespace ($.Values.riak.ClientPortProtobuf|int) -}}
+    {{- if lt $num  ( sub ($.Values.riak.replicas|int) 1 ) -}}
+      {{- printf "," -}}
+    {{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "dlConnect" }}


### PR DESCRIPTION
… (instead of just the service name)

This patch passes all riak replica addresses to the DataLayerService, so that it can form its own cluster view with those replicas.

Currently, the riak service URL is passed to the DataLayerService, such that its cluster view consists of only a single riak node. As a result, it falls back to eventual consistency instead of going for strong consistency for KV pairs.