### PR TITLE
Feature: use version numbers in deployment

### DIFF
--- a/deploy/helm/Makefile
+++ b/deploy/helm/Makefile
@@ -25,7 +25,8 @@ default: $(PKG)
 
 $(PKG): $(FILES)
 	rm -f $(PKG)
-	helm package --version $(VERSION) microfunctions/
+	sed 's/^version:.*/version: $(VERSION)/' -i microfunctions/Chart.yaml
+	helm package microfunctions/
 
 -include ../../docker.mk
 

--- a/deploy/helm/Makefile
+++ b/deploy/helm/Makefile
@@ -1,4 +1,4 @@
-#   Copyright 2020 The KNIX Authors
+#   Copyright 2021 The KNIX Authors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -12,7 +12,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-VERSION?=$(shell git describe --long --tags --dirty --always)
+SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+VERSION ?= $(shell git -C $(SELF_DIR) describe --tags --dirty)
 PKG=MicroFunctions-$(VERSION).tgz
 FILES=$(shell find microfunctions/)
 
@@ -23,11 +24,8 @@ default: $(PKG)
 .PHONY: push deploy undeploy
 
 $(PKG): $(FILES)
-	sed 's/^version:.*/version: $(VERSION)/' -i microfunctions/Chart.yaml
 	rm -f $(PKG)
-	helm dependency update microfunctions/
-	helm package microfunctions/
-	sed 's/^version:.*/version: auto/' -i microfunctions/Chart.yaml
+	helm package --version $(VERSION) microfunctions/
 
 -include ../../docker.mk
 

--- a/deploy/helm/microfunctions/Chart.yaml
+++ b/deploy/helm/microfunctions/Chart.yaml
@@ -1,4 +1,4 @@
-#   Copyright 2020 The KNIX Authors
+#   Copyright 2021 The KNIX Authors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -16,4 +16,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: High Performance Serverless system
 name: MicroFunctions
-version: auto
+version: 0.8.8

--- a/deploy/helm/microfunctions/templates/datalayer.yaml
+++ b/deploy/helm/microfunctions/templates/datalayer.yaml
@@ -1,4 +1,4 @@
-#   Copyright 2020 The KNIX Authors
+#   Copyright 2021 The KNIX Authors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -72,7 +72,7 @@ spec:
       #  effect: NoSchedule
       containers:
       - name: datalayer
-        image: "{{ .Values.imageRepo }}{{ .Values.datalayer.imagePath }}:{{ .Values.datalayer.imageTag }}"
+        image: "{{ .Values.imageRepo }}{{ .Values.datalayer.imagePath }}:{{ .Values.datalayer.imageTag | default .Values.imageTag | default .Chart.AppVersion }}"
         imagePullPolicy: "{{ .Values.datalayer.imagePullPolicy }}"
         env:
         - name: RIAK_CONNECT

--- a/deploy/helm/microfunctions/templates/management.yaml
+++ b/deploy/helm/microfunctions/templates/management.yaml
@@ -1,4 +1,4 @@
-#   Copyright 2020 The KNIX Authors
+#   Copyright 2021 The KNIX Authors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -163,7 +163,7 @@ data:
               {
                 "securityContext": { "runAsUser": 1000 },
                 "name": "sandbox",
-                "image": "{{ .Values.imageRepo }}{{ .Values.manager.sandbox.imagePathPython }}:{{ .Values.manager.sandbox.imageTag }}",
+                "image": "{{ .Values.imageRepo }}{{ .Values.manager.sandbox.imagePathPython }}:{{ .Values.manager.sandbox.imageTag | default .Values.imageTag | default .Chart.AppVersion }}",
                 "imagePullPolicy": "Always",
                 "env": [
                 {{/* not allowed in KNative
@@ -189,8 +189,8 @@ data:
   new_workflow.conf: |-
     {
       "app.fullname.prefix": "wf-{{ .Release.Name }}",
-      "image.Python": "{{ .Values.imageRepo }}{{ .Values.manager.sandbox.imagePathPython }}:{{ .Values.manager.sandbox.imageTag }}",
-      "image.Java": "{{ .Values.imageRepo }}{{ .Values.manager.sandbox.imagePathJava }}:{{ .Values.manager.sandbox.imageTag }}",
+      "image.Python": "{{ .Values.imageRepo }}{{ .Values.manager.sandbox.imagePathPython }}:{{ .Values.manager.sandbox.imageTag | default .Values.imageTag | default .Chart.AppVersion }}",
+      "image.Java": "{{ .Values.imageRepo }}{{ .Values.manager.sandbox.imagePathJava }}:{{ .Values.manager.sandbox.imageTag | default .Values.imageTag | default .Chart.AppVersion }}",
     {{- if (.Values.manager.createServiceAccounts) -}}
       "mgmtserviceaccount": "{{ template "manager.fullname" . }}",
     {{- else -}}
@@ -235,7 +235,7 @@ spec:
 {{ end }}
       containers:
       - name: management
-        image: "{{ .Values.imageRepo }}{{ .Values.manager.setup.imagePath }}:{{ .Values.manager.setup.imageTag }}"
+        image: "{{ .Values.imageRepo }}{{ .Values.manager.setup.imagePath }}:{{ .Values.manager.setup.imageTag | default .Values.imageTag | default .Chart.AppVersion }}"
         imagePullPolicy: "{{ .Values.manager.setup.imagePullPolicy }}"
         env:
         - name: MFN_HOSTNAME

--- a/deploy/helm/microfunctions/templates/nginx.yaml
+++ b/deploy/helm/microfunctions/templates/nginx.yaml
@@ -1,4 +1,4 @@
-#   Copyright 2020 The KNIX Authors
+#   Copyright 2021 The KNIX Authors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -127,7 +127,7 @@ spec:
         fsGroup: 101
       containers:
       - name: nginx
-        image: "{{ .Values.imageRepo }}{{ .Values.nginx.imagePath }}:{{ .Values.nginx.imageTag }}"
+        image: "{{ .Values.imageRepo }}{{ .Values.nginx.imagePath }}:{{ .Values.nginx.imageTag | default .Values.imageTag | default .Chart.AppVersion }}"
         imagePullPolicy: "{{ .Values.nginx.imagePullPolicy }}"
         ports:
         - name: http

--- a/deploy/helm/microfunctions/templates/predel-job.yaml
+++ b/deploy/helm/microfunctions/templates/predel-job.yaml
@@ -1,4 +1,4 @@
-#   Copyright 2020 The KNIX Authors
+#   Copyright 2021 The KNIX Authors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: {{ .Release.Name }}-postdelete
-        image: "{{ .Values.imageRepo }}{{ .Values.manager.setup.imagePath }}:{{ .Values.manager.setup.imageTag }}"
+        image: "{{ .Values.imageRepo }}{{ .Values.manager.setup.imagePath }}:{{ .Values.manager.setup.imageTag | default .Values.imageTag | default .Chart.AppVersion }}"
         resources:
 {{ toYaml .Values.manager.setup.resources | indent 10}}
         command:

--- a/deploy/helm/microfunctions/templates/riak.yaml
+++ b/deploy/helm/microfunctions/templates/riak.yaml
@@ -1,4 +1,4 @@
-#   Copyright 2020 The KNIX Authors
+#   Copyright 2021 The KNIX Authors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -97,7 +97,7 @@ spec:
         fsGroup: 1000
       containers:
       - name: riak
-        image: "{{ .Values.imageRepo }}{{ .Values.riak.imagePath }}:{{ .Values.riak.imageTag }}"
+        image: "{{ .Values.imageRepo }}{{ .Values.riak.imagePath }}:{{ .Values.riak.imageTag | default .Values.imageTag | default .Chart.AppVersion }}"
         imagePullPolicy: "{{ .Values.riak.imagePullPolicy }}"    
         envFrom:
         - configMapRef:

--- a/deploy/helm/microfunctions/templates/triggers_frontend.yaml
+++ b/deploy/helm/microfunctions/templates/triggers_frontend.yaml
@@ -1,4 +1,4 @@
-#   Copyright 2020 The KNIX Authors
+#   Copyright 2021 The KNIX Authors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@ spec:
         fsGroup: 1000
       containers:
       - name: triggers-frontend
-        image: "{{ .Values.imageRepo }}{{ .Values.triggersFrontend.imagePath }}:{{ .Values.triggersFrontend.imageTag }}"
+        image: "{{ .Values.imageRepo }}{{ .Values.triggersFrontend.imagePath }}:{{ .Values.triggersFrontend.imageTag | default .Values.imageTag | default .Chart.AppVersion }}"
         imagePullPolicy: "{{ .Values.triggersFrontend.imagePullPolicy }}"
         ports:
         - containerPort: {{ .Values.triggersFrontend.httpPort }}

--- a/deploy/helm/microfunctions/values.yaml
+++ b/deploy/helm/microfunctions/values.yaml
@@ -1,4 +1,4 @@
-#   Copyright 2020 The KNIX Authors
+#   Copyright 2021 The KNIX Authors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 # MicroFunction management workflow
 #------------------------------------------------------------------------------
 imageRepo: "registry.kube-system.svc.cluster.local"
+# imageTag: "latest" <- set all KNIX image tags to latest
 manager:
   #httpProxy: "http://<host>:<port>"
   #httpsProxy: "http://<host>:<port>"
@@ -33,7 +34,7 @@ manager:
       maxReplicas: 1
   setup:
     imagePath: "/microfn/management"
-    imageTag: "latest"
+    # imageTag: "latest" (default .Chart.AppVersion)
     imagePullPolicy: "Always"
     initialDelaySeconds: 60
     resources:
@@ -46,7 +47,7 @@ manager:
   sandbox:
     imagePathPython: "/microfn/sandbox"
     imagePathJava: "/microfn/sandbox_java"
-    imageTag: "latest"
+    # imageTag: "latest" (default .Chart.AppVersion)
     imagePullPolicy: "Always"
     resources:
       limits:
@@ -71,7 +72,7 @@ manager:
 datalayer:
   replicas: 3
   imagePath: "/microfn/datalayer"
-  imageTag: "latest"
+  # imageTag: "latest" (default .Chart.AppVersion)
   imagePullPolicy: "Always"
   port: 4998
   initialDelaySeconds: 0
@@ -79,10 +80,10 @@ datalayer:
   resources:
     limits:
       cpu: 4
-      memory: 8Gi
+      memory: 4Gi
     requests:
-      cpu: 4
-      memory: 8Gi
+      cpu: 1
+      memory: 2Gi
 
 #------------------------------------------------------------------------------
 # Riak global data storage
@@ -90,7 +91,7 @@ datalayer:
 riak:
   replicas: 3
   imagePath: "/microfn/riak"
-  imageTag: "latest"
+  # imageTag: "latest" (default .Chart.AppVersion)
   imagePullPolicy: "Always"
   nameOverride: "microfunctions-riak"
   ClientPortHttp: 8098
@@ -143,7 +144,7 @@ nginx:
   Replicas: 1
   nameOverride: "microfunctions-nginx"
   imagePath: "/microfn/nginx"
-  imageTag: "latest"
+  # imageTag: "latest" (default .Chart.AppVersion)
   httpPort: 32180
   location: "/"
 # If httpsPort is defined, the Base64 encoded certificate authority, certificate and key are required to serve securely from the Pod
@@ -165,7 +166,7 @@ nginx:
 #------------------------------------------------------------------------------
 triggersFrontend:
   imagePath: "/microfn/triggers_frontend"
-  imageTag: "latest"
+  # imageTag: "latest" (default .Chart.AppVersion)
   imagePullPolicy: "Always"
   nameOverride: "microfunctions-triggers-frontend"
   httpPort: 4997

--- a/docker.mk
+++ b/docker.mk
@@ -3,48 +3,50 @@
 ##
 SHELL := /bin/bash
 REGISTRY ?= localhost:5000
-VERSION ?= latest #$(shell git describe --tags)
+SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+VERSION ?= $(shell git -C $(SELF_DIR) describe --tags --dirty)
 
 define build_image
 	@#echo "Dockerfile $(1)"
 	@#echo "container $(2)"
 	@#echo "Current dependencies $^"
-	@CDATE=$$(docker image inspect $(2) --format '{{.Created}}'); \
+	@CDATE=$$(docker image inspect $(2):$(VERSION) --format '{{.Created}}'); \
 	if [[ $$? != 0 ]]; then \
 		docker pull $(REGISTRY)/$(2):$(VERSION); \
-		docker tag $(REGISTRY)/$(2):$(VERSION) $(2); \
-		CDATE=$$(docker image inspect $(2) --format '{{.Created}}'|| echo "1970-01-01 00:00:00.000000"); \
+		docker tag $(REGISTRY)/$(2):$(VERSION) $(2):$(VERSION); \
+		CDATE=$$(docker image inspect $(2):$(VERSION) --format '{{.Created}}'|| echo "1970-01-01 00:00:00.000000"); \
 	fi; \
 	CTIME=$$(date --date="$$(echo $$CDATE | awk '{print $$1" "$$2}')" +"%s"); \
 	for file in $^; do \
 	  if [[ $$CTIME -lt $$(stat -c %Y $$file) ]]; then \
 	    echo "$$file is newer than the container"; \
-	    OLDID=$$(docker images $(2) --format '{{.ID}}'); \
+	    OLDID=$$(docker images $(2):$(VERSION) --format '{{.ID}}'); \
 	    docker -D -l debug build \
 			--build-arg http_proxy=$${HTTP_PROXY:-$${http_proxy:-$(HTTP_PROXY)}} \
 			--build-arg https_proxy=$${HTTPS_PROXY:-$${https_proxy:-$(HTTP_PROXY)}} \
+			--build-arg VERSION=$(VERSION) \
 			-f $(1) \
-			-t $(2) . || exit $$!; \
-	    NEWID=$$(docker images $(2) --format '{{.ID}}'|grep -v "$$OLDID"); \
+			-t $(2):$(VERSION) . || exit $$!; \
+	    NEWID=$$(docker images $(2):$(VERSION) --format '{{.ID}}'|grep -v "$$OLDID"); \
 	    if [[ ! -z "$$OLDID" && ! -z "$$NEWID" ]]; then echo "Removing image $$OLDID"; docker rmi $$OLDID; fi; \
 	    break; \
 	  fi; \
-	done; if [ -z "$$NEWID" ]; then echo "Container image $(2) is already up-to-date"; fi
+	done; if [ -z "$$NEWID" ]; then echo "Container image $(2):$(VERSION) is already up-to-date"; fi
 endef
 
 define push_image
 	@#echo local image name $(1)
-	ID=$$(docker images $(1) --format '{{.ID}}'); \
+	ID=$$(docker images $(1):$(VERSION) --format '{{.ID}}'); \
 	MANIFEST=$$(curl -s -H 'Accept: application/vnd.docker.distribution.manifest.v2+json' https://$(REGISTRY)/v2/$(1)/manifests/$(VERSION) || echo "")
 	if [[ -z "$${MANIFEST}" ]]; then \
 		MANIFEST=$$(curl -s -H 'Accept: application/vnd.docker.distribution.manifest.v2+json' http://$(REGISTRY)/v2/$(1)/manifests/$(VERSION) || echo ""); \
 	fi; \
 	RID=$$(echo $$MANIFEST|python -c 'import json; import sys; print(json.loads(sys.stdin.read())["config"]["digest"].split(":")[1])' 2>/dev/null|| echo ""); \
 	if [[ ! -z "$${ID}" && ! -z "$${RID}" && "$${RID}" == "$${ID}"* ]]; then \
-		echo "Already pushed local image $(1) ($${ID}) as $(REGISTRY)/$(1):$(VERSION) ($${RID})"; \
+		echo "Already pushed local image $(1):$(VERSION) ($${ID}) as $(REGISTRY)/$(1):$(VERSION) ($${RID})"; \
 	else \
-		echo "Tagging and pushing $(1) as $(REGISTRY)/$(1):$(VERSION)"; \
-		docker tag $(1) $(REGISTRY)/$(1):$(VERSION) || exit $$?; \
+		echo "Tagging and pushing $(1):$(VERSION) as $(REGISTRY)/$(1):$(VERSION)"; \
+		docker tag $(1):$(VERSION) $(REGISTRY)/$(1):$(VERSION) || exit $$?; \
 		docker push $(REGISTRY)/$(1):$(VERSION) || exit $$?; \
 	fi
 endef


### PR DESCRIPTION
Current state:
Helm chart deploys components with tag latest, can be overwritten manually (.Values.<component>.imageTag)
Images are by default built with tag latest, can be build with a different tag (export VERSION=...)

Expected:
The default should use version numbers on container images to avoid confusions over what is deployed. Using version numbers by default allows to quickly see what is deployed when debugging user's setups. Also when builds fail silently, it is not clear which version is contained in the image tagged latest.

What has been done in the PR:
- the version number detected with the git command may fail if called from another repo clone, use SELF_DIR to determine the Makefile's location before getting the version number
- Use version tag on the pull and tag commands in docker.mk, the current script always uses the latest to find if the image has already been built
- Helm: use version from .Chart.AppVersion (set during packaging in Makefile), but allow to easily use latest on all KNIX images by setting the single Helm value .imageTag, also (as before), allow individual version numbers on images