### PR TITLE
Feature/handle remote results

### DIFF
--- a/FunctionWorker/python/FunctionWorker.py
+++ b/FunctionWorker/python/FunctionWorker.py
@@ -93,7 +93,7 @@ class FunctionWorker:
         if self._is_session_workflow:
             self._session_utils = SessionUtils(self._worker_params, self._publication_utils, self._logger)
 
-        # TODO: SAPI
+        # SAPI
         # pass the SessionUtils object for API calls to send a message to other running functions?
         # MicroFunctionsAPI object checks before sending a message (i.e., allow only if this is_session_workflow is True)
         # Maybe allow only if the destination is a session function? Requires a list of session functions and passing them to the MicroFunctionsAPI and SessionUtils

--- a/FunctionWorker/python/PublicationUtils.py
+++ b/FunctionWorker/python/PublicationUtils.py
@@ -407,7 +407,7 @@ class PublicationUtils():
                 action_data["topic"] = next
                 action_data["key"] = key
                 action_data["value"] = trigger["value"]
-                # TODO: include the metadata about __origin_client_frontend
+                # include also the metadata about __origin_client_frontend
                 action_data["client_origin_frontend"] = self._metadata["__client_origin_frontend"]
 
                 self._send_remote_message(trigger["remote_address"], "session-update", action_data)

--- a/FunctionWorker/python/PublicationUtils.py
+++ b/FunctionWorker/python/PublicationUtils.py
@@ -71,6 +71,9 @@ class PublicationUtils():
         self._execution_info_map_name = None
         self._next_backup_list = []
 
+        self._internal_endpoint = worker_params["internal_endpoint"]
+        self._external_endpoint = worker_params["external_endpoint"]
+
         #self._logger.debug("[PublicationUtils] init done.")
 
     def set_workflow_local_functions(self, wf_local):
@@ -306,38 +309,29 @@ class PublicationUtils():
         while not ack:
             ack = lqcpub.addMessage(lqtopic, lqcm, True)
 
-    def _send_remote_message(self, remote_address, message_type, lqtopic, key, value):
+    def _send_remote_message(self, remote_address, message_type, action_data):
         # form a http request to send to remote host
         # need to set async=true in request URL, so that the frontend does not have a sync object waiting
-        if message_type == "session_update":
-            # if a session update message, set headers appropriately
-            action_data = {}
-            action_data["topic"] = lqtopic
-            action_data["key"] = key
-            action_data["value"] = value
 
-            # exponential backoff
-            retry = 0.1
-            # retry 7 times, wait for 5 seconds for the connection to time out
-            while retry <= 6.4:
-                try:
-                    resp = requests.post(remote_address,
-                                         params={"async": 1},
-                                         json={},
-                                         timeout=5,
-                                         headers={"x-mfn-action": "session-update",
-                                                  "x-mfn-action-data": json.dumps(action_data)})
-                except Exception as exc:
-                    self._logger.info("Sending remote message failed: " + str(exc) + "; retrying in: " + str(retry) + "s")
-                    time.sleep(retry)
-                    retry = retry * 2
+        # exponential backoff
+        retry = 0.1
+        # retry 7 times, wait for 5 seconds for the connection to time out
+        while retry <= 6.4:
+            try:
+                resp = requests.post(remote_address,
+                                     params={"async": 1},
+                                     json={},
+                                     timeout=5,
+                                     headers={"x-mfn-action": message_type,
+                                              "x-mfn-action-data": json.dumps(action_data)})
+            except Exception as exc:
+                self._logger.info("Sending remote message (" + message_type + ") failed: " + str(exc) + "; retrying in: " + str(retry) + "s")
+                time.sleep(retry)
+                retry = retry * 2
 
-            if retry > 6.4:
-                self._logger.info("Could not send remote message due to timeouts.")
+        if retry > 6.4:
+            self._logger.info("Could not send remote message (" + message_type + ") due to timeouts.")
 
-        elif message_type == "global_pub":
-            # TODO: if global publishing, set headers appropriately (e.g., for load balancing)
-            pass
 
     def _publish_privileged_output(self, function_output, lqcpub):
         next = function_output["next"]
@@ -408,7 +402,14 @@ class PublicationUtils():
                 self._send_local_queue_message(lqcpub, next, key, trigger["value"])
             else:
                 # send it to the remote host with a special header
-                self._send_remote_message(trigger["remote_address"], "session_update", next, key, trigger["value"])
+                action_data = {}
+                action_data["topic"] = next
+                action_data["key"] = key
+                action_data["value"] = trigger["value"]
+                # TODO: include the metadata about __origin_client_frontend
+
+                self._send_remote_message(trigger["remote_address"], "session-update", action_data)
+
             return (None, None)
         elif "is_privileged" in trigger and trigger["is_privileged"]:
             # next[0:6] == "async_"
@@ -431,9 +432,11 @@ class PublicationUtils():
                     timestamp_map['t_pub_localqueue'] = time.time() * 1000.0
                 self._send_local_queue_message(lqcpub, topic_next, key, output["value"])
             else:
+                # TODO: global publishing, set headers appropriately "global-pub" (e.g., for load balancing)
                 # TODO: need to also ensure that a message to a non-local topic gets properly handled
                 # for multi-host deployments for load redirection
                 # currently, we don't have such cases
+
                 self._send_local_queue_message(lqcpub, topic_next, key, output["value"])
 
                 # check if 'next' is exit topic
@@ -444,11 +447,26 @@ class PublicationUtils():
 
                     key = self._metadata["__execution_id"]
 
+                    # TODO: check __client_origin_frontend in metadata
+                    # TODO: compile remote-result message
+                    # TODO: send remote message directly to the origin frontend
+                    # TODO: ensure that remote address is not our frontend
+                    if "__client_origin_frontend" in self._metadata and self._internal_endpoint != self._metadata["__client_origin_frontend"]:
+                        remote_result_message = {}
+                        remote_result_message["key"] = key
+                        remote_result_message["value"] = output["value"]
+
+                        self._send_remote_message(self._metadata["__client_origin_frontend"], "remote-result", remote_result_message)
+
                     dlc = self._get_backup_data_layer_client()
 
                     # store the workflow's final result
                     dlc.put("result_" + key, output["value"])
                     #self._logger.debug("[__mfn_backup] [exitresult] [%s] %s", "result_" + key, output["value"])
+
+                else:
+
+
 
             return (next_function_execution_id, output)
 

--- a/FunctionWorker/python/SessionUtils.py
+++ b/FunctionWorker/python/SessionUtils.py
@@ -447,7 +447,9 @@ class SessionUtils:
         trigger["value"] = message
         trigger["to_running_function"] = True
         trigger["next"] = function_metadata["communicationTopic"]
-        if self._hostname == function_metadata["hostname"]:
+        # TESTING: the below check should be about equality '=='
+        #if self._hostname == function_metadata["hostname"]:
+        if self._hostname != function_metadata["hostname"]:
             # local function instance; send it via local queue
             #self._logger.debug("[SessionUtils] Local session function: " + str(session_function_id))
             trigger["is_local"] = True

--- a/FunctionWorker/python/SessionUtils.py
+++ b/FunctionWorker/python/SessionUtils.py
@@ -447,9 +447,7 @@ class SessionUtils:
         trigger["value"] = message
         trigger["to_running_function"] = True
         trigger["next"] = function_metadata["communicationTopic"]
-        # TESTING: the below check should be about equality '=='
-        #if self._hostname == function_metadata["hostname"]:
-        if self._hostname != function_metadata["hostname"]:
+        if self._hostname == function_metadata["hostname"]:
             # local function instance; send it via local queue
             #self._logger.debug("[SessionUtils] Local session function: " + str(session_function_id))
             trigger["is_local"] = True
@@ -460,7 +458,7 @@ class SessionUtils:
             trigger["remote_address"] = function_metadata["remote_address"]
 
         if send_now:
-            self._publication_utils.send_to_function_now("-1l", trigger)
+            self._publication_utils.send_to_function_now(self._key, trigger)
         else:
             self._publication_utils.append_trigger(trigger)
 

--- a/Sandbox/frontend/frontend.go
+++ b/Sandbox/frontend/frontend.go
@@ -345,7 +345,6 @@ func handler(w http.ResponseWriter, r *http.Request) {
       if (actionhdr == "session-update") {
           log.Printf("New session update message...")
 
-          // TODO: need to get additional metadata about __client_origin_frontend
           type ActionMessage struct {
               Topic string `json:"topic"`
               Key string `json:"key"`
@@ -432,6 +431,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
         msg.Mfnmetadata.AsyncExecution = async
         msg.Mfnmetadata.ExecutionId = id
         msg.Mfnmetadata.FunctionExecutionId = id
+        msg.Mfnmetadata.ClientOriginFrontend = internalEndpoint
         msg.Mfnmetadata.TimestampFrontendEntry = float64(time.Now().UnixNano()) / float64(1000000000.0)
         body, err := ioutil.ReadAll(r.Body)
         if err != nil {
@@ -443,7 +443,6 @@ func handler(w http.ResponseWriter, r *http.Request) {
         topic = actiondata
         log.Printf("Trigger-Event message topic: [%s], id: [%s]", topic, id)
     } else if (actionhdr == "remote-result") {
-        // TODO
         log.Printf("New remote result message...")
 
         type ActionMessage struct {
@@ -465,7 +464,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
         msg := MfnMessage{}
         err = msg.UnmarshalJSON(valueb)
 
-        // TODO: get the execution context and signal that the result is available
+        // get the execution context and signal that the result is available
         ExecutionCond.L.Lock()
         e, ok := ExecutionResults[msg.Mfnmetadata.ExecutionId]
         ExecutionCond.L.Unlock()
@@ -493,12 +492,12 @@ func handler(w http.ResponseWriter, r *http.Request) {
         return
       }
 
-      // TODO: metadata about __client_origin_frontend
       msg = MfnMessage{}
       msg.Mfnmetadata = &Metadata{}
       msg.Mfnmetadata.AsyncExecution = async
       msg.Mfnmetadata.ExecutionId = id
       msg.Mfnmetadata.FunctionExecutionId = id
+      msg.Mfnmetadata.ClientOriginFrontend = internalEndpoint
       msg.Mfnmetadata.TimestampFrontendEntry = float64(time.Now().UnixNano()) / float64(1000000000.0)
       body, err := ioutil.ReadAll(r.Body)
       if err != nil {

--- a/Sandbox/frontend/frontend.go
+++ b/Sandbox/frontend/frontend.go
@@ -350,6 +350,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
               Topic string `json:"topic"`
               Key string `json:"key"`
               Value string `json:"value"`
+              ClientOriginFrontend string `json:"client_origin_frontend"`
           }
           var data ActionMessage
           bactiondata := []byte(actiondata)
@@ -369,6 +370,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
           msg.Mfnmetadata.AsyncExecution = async
           msg.Mfnmetadata.ExecutionId = id
           msg.Mfnmetadata.FunctionExecutionId = id
+          msg.Mfnmetadata.ClientOriginFrontend = data.ClientOriginFrontend
           msg.Mfnmetadata.TimestampFrontendEntry = float64(time.Now().UnixNano()) / float64(1000000000.0)
 
           msg.Mfnuserdata = data.Value

--- a/Sandbox/frontend/frontend.go
+++ b/Sandbox/frontend/frontend.go
@@ -16,26 +16,26 @@
 package main
 
 import (
-	"bufio"
-	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io/ioutil"
-	"log"
-	"net/http"
-	"os"
-	"os/signal"
-	"strings"
-	"sync"
-	"syscall"
-	"time"
+    "bufio"
+    "context"
+    "encoding/json"
+    "errors"
+    "fmt"
+    "io/ioutil"
+    "log"
+    "net/http"
+    "os"
+    "os/signal"
+    "strings"
+    "sync"
+    "syscall"
+    "time"
 
-	"github.com/apache/thrift/lib/go/thrift"
-	"github.com/go-redis/redis/v8"
-	"github.com/google/uuid"
-	"github.com/knix-microfunctions/knix/Sandbox/frontend/datalayermessage"
-	"github.com/knix-microfunctions/knix/Sandbox/frontend/datalayerservice"
+    "github.com/apache/thrift/lib/go/thrift"
+    "github.com/go-redis/redis/v8"
+    "github.com/google/uuid"
+    "github.com/knix-microfunctions/knix/Sandbox/frontend/datalayermessage"
+    "github.com/knix-microfunctions/knix/Sandbox/frontend/datalayerservice"
 )
 
 // custom log writer to overwrite the default log format
@@ -84,6 +84,11 @@ var (
 // Consumer (see ConsumeResults() uses a global result topic set by main()
 var (
   resultTopic string
+)
+
+var (
+  internalEndpoint string
+  externalEndpoint string
 )
 
 // Datalayer is used to store checkpoints when sending a message and to retrieve results of executions by the HTTP handler
@@ -340,6 +345,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
       if (actionhdr == "session-update") {
           log.Printf("New session update message...")
 
+          // TODO: need to get additional metadata about __client_origin_frontend
           type ActionMessage struct {
               Topic string `json:"topic"`
               Key string `json:"key"`
@@ -434,6 +440,46 @@ func handler(w http.ResponseWriter, r *http.Request) {
         msg.Mfnuserdata = string(body)
         topic = actiondata
         log.Printf("Trigger-Event message topic: [%s], id: [%s]", topic, id)
+    } else if (actionhdr == "remote-result") {
+        // TODO
+        log.Printf("New remote result message...")
+
+        type ActionMessage struct {
+            Key string `json:"key"`
+            Value string `json:"value"`
+        }
+        var data ActionMessage
+        bactiondata := []byte(actiondata)
+        err := json.Unmarshal(bactiondata, &data)
+        if err != nil {
+            log.Printf("handler: Couldn't unmarshal remote result message: %s", err)
+            log.Fatal(err)
+        }
+
+        log.Printf("Parsed remote result message: id: [%s], result: [%s]", data.Key, data.Value)
+
+        valueb := []byte(data.Value)
+
+        msg := MfnMessage{}
+        err = msg.UnmarshalJSON(valueb)
+
+        // TODO: get the execution context and signal that the result is available
+        ExecutionCond.L.Lock()
+        e, ok := ExecutionResults[msg.Mfnmetadata.ExecutionId]
+        ExecutionCond.L.Unlock()
+        if !ok {
+            log.Println("handler: Received unknown remote result", string(msg.Mfnmetadata.ExecutionId))
+            return
+        }
+        log.Println("handler: Received remote result for ID", msg.Mfnmetadata.ExecutionId)
+        e.cond.L.Lock()
+        e.rt_rcvdlq = rt_rcvdlq
+        e.msg = &msg
+        e.cond.Broadcast()
+        e.cond.L.Unlock()
+
+        // this special message doesn't trigger the workflow; therefore, need to stop here
+        return
     }
   } else {
       is_special_message = false
@@ -445,6 +491,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
         return
       }
 
+      // TODO: metadata about __client_origin_frontend
       msg = MfnMessage{}
       msg.Mfnmetadata = &Metadata{}
       msg.Mfnmetadata.AsyncExecution = async
@@ -737,7 +784,7 @@ func Fakeit(msg *MfnMessage) (error) {
 }
 
 func init() {
-	initResourceStats()
+    initResourceStats()
 }
 
 // The frontend initializes datalayer and producer thrift clients, starts consumer as a go routine, registers a signal handler for graceful shutdowns and blocks at starting the http server
@@ -749,6 +796,8 @@ func main() {
   fmt.Println("Frontend starting ...")
   entryTopic  = os.Getenv("MFN_ENTRYTOPIC")
   resultTopic = os.Getenv("MFN_RESULTTOPIC")
+  internalEndpoint = os.Getenv("MFN_INTERNAL_ENDPOINT")
+  externalEndpoint = os.Getenv("MFN_EXTERNAL_ENDPOINT")
   fmt.Println("consuming results from", resultTopic)
   datalayerKeyspace = "sbox_"+os.Getenv("SANDBOXID")
   datalayerTable = "sbox_default_" + os.Getenv("SANDBOXID")

--- a/Sandbox/schema/mfnmessage-schema.json
+++ b/Sandbox/schema/mfnmessage-schema.json
@@ -16,6 +16,7 @@
         "required": [
           "__execution_id",
           "__async_execution",
+          "__client_origin_frontend",
           "__function_execution_id",
           "__timestamp_frontend_entry"
         ],
@@ -38,6 +39,15 @@
             "examples": [
               true,
               false
+            ]
+          },
+          "__client_origin_frontend": {
+            "$id": "#/properties/__mfnmetadata/properties/__client_origin_frontend",
+            "type": "string",
+            "title": "ClientOriginFrontend",
+            "default": "",
+            "examples": [
+              "http://10.20.20.10:8080", "http://192.168.0.100:49125"
             ]
           },
           "__function_execution_id": {

--- a/SandboxAgent/sandboxagent.py
+++ b/SandboxAgent/sandboxagent.py
@@ -360,6 +360,8 @@ class SandboxAgent:
         fenv["MFN_ENTRYTOPIC"] = workflow.getWorkflowEntryTopic()
         fenv["MFN_RESULTTOPIC"] = workflow.getWorkflowExitTopic()
         fenv["MFN_QUEUE"] = self._queue
+        fenv["MFN_EXTERNAL_ENDPOINT"] = self._external_endpoint
+        fenv["MFN_INTERNAL_ENDPOINT"] = self._internal_endpoint
         # MFN_DATALAYER already set
 
         command_args_map_fe = {}

--- a/deploy/ansible/datalayer.yaml
+++ b/deploy/ansible/datalayer.yaml
@@ -25,18 +25,20 @@
 
     service_name: mfn-datalayer
     service_script: "/lib/systemd/system/{{ service_name }}.service"
-    datalayer_bind: "{{ ansible_default_ipv4.address }}:4998"
-    riak_connect: "{{ hostvars[groups['riak'][0]].ansible_default_ipv4.address }}:8087"
-    all_datalayer_hosts_bind: "{{ groups['all']|map('extract',hostvars)|map(attribute='ansible_default_ipv4.address')|join(':4998,') }}:4998"
+    datalayer_bind: "{{ ansible_ssh_host }}:4998"
+    riak_connect: "{{ hostvars[groups['riak'][0]].ansible_ssh_host }}:8087"
+    all_datalayer_hosts_bind: "{{ groups['all']|map('extract',hostvars)|map(attribute='ansible_ssh_host')|join(':4998,') }}:4998"
 
   tasks:
 
   - debug:
       msg: 
         - inventory_hostname = {{ inventory_hostname }}
-        - ansible_default_ipv4.address = {{ ansible_default_ipv4.address }}
+        - host_ip_address = {{ ansible_ssh_host }}
         - install_dir = {{ install_dir }}    # e.g. /opt/mfn
         - "datalayer package = {{ datalayer_dist }}/{{ datalayer_jar }}"
+        - riak_connect = {{ riak_connect }}
+        - all_datalayer_hosts_bind = {{ all_datalayer_hosts_bind }}
 
   - name: stop service
     systemd:
@@ -78,7 +80,7 @@
         [Unit]
         Description=Microfunctions Datalayer
         After=network.target
-        Requires=mfn-riak.service
+        #Requires=mfn-riak.service
         [Service]
         Type=simple
         WorkingDirectory={{ install_dir }}

--- a/deploy/ansible/elasticsearch.yaml
+++ b/deploy/ansible/elasticsearch.yaml
@@ -26,7 +26,7 @@
     es_installer_archive_filename: "{{ es_installer_archive_version }}-linux-x86_64.tar.gz"
 
     es_master_name: "{{ groups['elasticsearch'][0] }}"
-    es_master_ip: "{{ hostvars[groups['elasticsearch'][0]].ansible_default_ipv4.address }}"
+    es_master_ip: "{{ hostvars[groups['elasticsearch'][0]].ansible_ssh_host }}"
 
     # Paths on target machine (where elasticsearch will be installed)
     es_server_dir: "{{ mfn_server_installation_folder }}/elasticsearch"
@@ -46,7 +46,7 @@
     es_server_service_path: "/lib/systemd/system/{{ es_server_service_name }}.service"
     es_server_cluster_name: mfn-elasticsearch
 
-    elasticsearch_connect: "{{ hostvars[groups['elasticsearch'][0]].ansible_default_ipv4.address }}:9200"
+    elasticsearch_connect: "{{ hostvars[groups['elasticsearch'][0]].ansible_ssh_host }}:9200"
 
   tasks:
   - name: get http_proxy
@@ -70,7 +70,7 @@
   - debug:
       msg: 
         - inventory_hostname = {{ inventory_hostname }}
-        - ansible_default_ipv4.address = {{ ansible_default_ipv4.address }}
+        - ansible_ssh_host = {{ ansible_ssh_host }}
         - mfn_server_installation_folder = {{ mfn_server_installation_folder }}      # e.g. /opt/mfn
         - es_server_dir = {{ es_server_dir }}                                        # e.g. /opt/mfn/elasticsearch
         - es_server_config_filename = {{ es_server_config_filename }}                # e.g. elasticsearch.yml
@@ -152,11 +152,11 @@
       regexp: "node.name:"
       line: "node.name: {{ inventory_hostname }}"
 
-  - name: "Update {{ es_server_config_filepath }}   network.host: {{ ansible_default_ipv4.address }}"
+  - name: "Update {{ es_server_config_filepath }}   network.host: {{ ansible_ssh_host }}"
     lineinfile:
       path: "{{ es_server_config_filepath }}"
       regexp: "network.host:"
-      line: "network.host: {{ ansible_default_ipv4.address }}"
+      line: "network.host: {{ ansible_ssh_host }}"
 
   - name: "Update {{ es_server_config_filepath }}   path.data: {{ es_server_dir_data }}"
     lineinfile:
@@ -172,11 +172,11 @@
 
 
   # these could be the names of all the hosts in the cluster
-  - name: "Update {{ es_server_config_filepath }}   discovery.seed_hosts: [\"{{ groups['elasticsearch']|map('extract',hostvars)|map(attribute='ansible_default_ipv4.address')|join('\", \"')}}\"]"
+  - name: "Update {{ es_server_config_filepath }}   discovery.seed_hosts: [\"{{ groups['elasticsearch']|map('extract',hostvars)|map(attribute='ansible_ssh_host')|join('\", \"')}}\"]"
     lineinfile:
       path: "{{ es_server_config_filepath }}"
       regexp: "discovery.seed_hosts:"
-      line: "discovery.seed_hosts: [\"{{ groups['elasticsearch']|map('extract',hostvars)|map(attribute='ansible_default_ipv4.address')|join('\", \"')}}\"]"
+      line: "discovery.seed_hosts: [\"{{ groups['elasticsearch']|map('extract',hostvars)|map(attribute='ansible_ssh_host')|join('\", \"')}}\"]"
   
   # always points to the master node
   - name: "Update {{ es_server_config_filepath }}   cluster.initial_master_nodes: [\"{{ es_master_name }}\"]"
@@ -272,7 +272,7 @@
         #config file path: {{ es_server_dir_config }}
         cd {{ es_server_dir }}
         sudo systemctl start {{ es_server_service_name }}
-        {{ mfn_server_installation_folder }}/wait-for-it.sh {{ ansible_default_ipv4.address }}:9200 -t 60
+        {{ mfn_server_installation_folder }}/wait-for-it.sh {{ ansible_ssh_host }}:9200 -t 60
         ./esconfig.sh
         cd -
 
@@ -296,7 +296,7 @@
         sudo rm -rf logs/*
 
   - name: wait for elasticsearch
-    shell: "{{ mfn_server_installation_folder }}/wait-for-it.sh {{ ansible_default_ipv4.address }}:9200 -t 180"
+    shell: "{{ mfn_server_installation_folder }}/wait-for-it.sh {{ ansible_ssh_host }}:9200 -t 180"
     register: wait_result
 
   - name: waiting result
@@ -315,11 +315,11 @@
       HTTP_PROXY: "{{ http_proxy }}"
       HTTPS_PROXY: "{{ https_proxy }}"
     register: esconfig_command
-    when: ansible_default_ipv4.address == es_master_ip
+    when: ansible_ssh_host == es_master_ip
   
   - debug:
       var: esconfig_command.stdout
-    when: ansible_default_ipv4.address == es_master_ip
+    when: ansible_ssh_host == es_master_ip
 
 #  - name: systemd install and disable mfn-elasticsearch service
 #    systemd:

--- a/deploy/ansible/fluentbit.yaml
+++ b/deploy/ansible/fluentbit.yaml
@@ -21,7 +21,7 @@
     fluentbit_dir: "../../LoggingService/fluent-bit"
     install_dir: "{{ mfn_server_installation_folder }}/fluentbit"
     conf_dir: "{{ install_dir }}/conf"
-    elasticsearch_host: "{{ hostvars[groups['elasticsearch'][0]].ansible_default_ipv4.address }}"
+    elasticsearch_host: "{{ hostvars[groups['elasticsearch'][0]].ansible_ssh_host }}"
     elasticsearch_port: 9200
     service_name: mfn-fluentbit
     service_script: "/lib/systemd/system/{{ service_name }}.service"
@@ -59,7 +59,7 @@
   - debug:
       msg: 
       - inventory_hostname = {{ inventory_hostname }}
-      - ansible_default_ipv4.address = {{ ansible_default_ipv4.address }}
+      - ansible_ssh_host = {{ ansible_ssh_host }}
       - mfn_server_installation_folder = {{ mfn_server_installation_folder }}    # e.g. /opt/mfn
       - install_dir = {{ install_dir }}
       - conf_dir = {{ conf_dir }}

--- a/deploy/ansible/init_once.yaml
+++ b/deploy/ansible/init_once.yaml
@@ -35,7 +35,7 @@
   - debug:
       msg:
       - inventory_hostname = {{ inventory_hostname }}
-      - ansible_default_ipv4.address = {{ ansible_default_ipv4.address }}
+      - ansible_ssh_host = {{ ansible_ssh_host }}
       - mfn_server_installation_folder = {{ mfn_server_installation_folder }}
       - proxy settings files = ./proxy/
       - http_proxy = {{ http_proxy }}
@@ -78,7 +78,7 @@
     lineinfile:
       path: "/etc/hosts"
       insertafter: EOF
-      line: "{{ ansible_default_ipv4.address }} {{ inventory_hostname }} {{ inventory_hostname }}"
+      line: "{{ ansible_ssh_host }} {{ inventory_hostname }} {{ inventory_hostname }}"
 
   - name: ensure docker is at the latest version
     apt: name=docker-ce update_cache=yes

--- a/deploy/ansible/knix-mfn.nginx.conf.j2
+++ b/deploy/ansible/knix-mfn.nginx.conf.j2
@@ -1,6 +1,6 @@
 upstream knix_management {
 {% for host in groups['management'] %}
-        server {{ hostvars[host].ansible_default_ipv4.address }}:{{ management_service_exposed_port }};
+        server {{ hostvars[host].ansible_ssh_host }}:{{ management_service_exposed_port }};
 {% endfor %}
 }
 

--- a/deploy/ansible/local_inventory.sh
+++ b/deploy/ansible/local_inventory.sh
@@ -14,20 +14,24 @@
 #   limitations under the License.
 
 HOSTNAME=$(/bin/hostname -f)
+# get hostip via ping, so that it is using the public IP
+HOSTIP=$(ping $HOSTNAME -c 1 | head -1 | awk '{print $3}' | awk 'BEGIN {FS="[()]"}; {print $2}')
 
+# ansible_ssh_host will be utilized to map the IP addresses to the publicly available IP address
+# (i.e., the one connected by ansible master)
 cat <<END >inventory.cfg
 [riak]
-$HOSTNAME
+$HOSTNAME ansible_ssh_host=$HOSTIP
 
 [elasticsearch]
-$HOSTNAME
+$HOSTNAME ansible_ssh_host=$HOSTIP
 
 [management]
-$HOSTNAME
+$HOSTNAME ansible_ssh_host=$HOSTIP
 
 [nginx]
-$HOSTNAME
+$HOSTNAME ansible_ssh_host=$HOSTIP
 
 [triggers_frontend]
-$HOSTNAME
+$HOSTNAME ansible_ssh_host=$HOSTIP
 END

--- a/deploy/ansible/management.yaml
+++ b/deploy/ansible/management.yaml
@@ -23,10 +23,10 @@
     management_archive_filename: management_deployment_package.tar.gz
 
     install_dir: "{{ mfn_server_installation_folder }}/management"
-    datalayer_connect: "{{ ansible_default_ipv4.address }}:4998" # same host
-    elasticsearch_connect: "{{ hostvars[groups['elasticsearch'][0]].ansible_default_ipv4.address }}:9200"
+    datalayer_connect: "{{ ansible_ssh_host }}:4998" # same host
+    elasticsearch_connect: "{{ hostvars[groups['elasticsearch'][0]].ansible_ssh_host }}:9200"
     nginx_http_listen_port: "{{ nginx_http_listen_port }}"
-    nginx_connect: "{{ hostvars[groups['nginx'][0]].ansible_default_ipv4.address }}:{{ nginx_http_listen_port }}"
+    nginx_connect: "{{ hostvars[groups['nginx'][0]].ansible_ssh_host }}:{{ nginx_http_listen_port }}"
 
   tasks:
 
@@ -50,7 +50,7 @@
   - debug:
       msg:
       - inventory_hostname = {{ inventory_hostname }}
-      - ansible_default_ipv4.address = {{ ansible_default_ipv4.address }}
+      - ansible_ssh_host = {{ ansible_ssh_host }}
       - mfn_server_installation_folder = {{ mfn_server_installation_folder }}    # e.g. /opt/mfn
       - management_service_dir = {{ management_service_dir }}
       - management_archive_filename = {{ management_archive_filename }}

--- a/deploy/ansible/nginx.yaml
+++ b/deploy/ansible/nginx.yaml
@@ -49,7 +49,7 @@
   - debug:
       msg:
         - inventory_hostname = {{ inventory_hostname }}
-        - ansible_default_ipv4.address = {{ ansible_default_ipv4.address }}
+        - ansible_ssh_host = {{ ansible_ssh_host }}
         - mfn_server_installation_folder = {{ mfn_server_installation_folder }}    # e.g. /opt/mfn
         - install_dir = {{ install_dir }}
         - frontend_http_listen_port = {{ frontend_http_listen_port }}
@@ -121,7 +121,7 @@
         - "DNS:{{ ansible_fqdn }}"
         - "DNS:{{ ansible_hostname }}"
         - "{{ inventory_hostname | ipaddr() | ternary( 'IP:', 'DNS:') }}{{ inventory_hostname }}"
-        - "IP:{{ ansible_default_ipv4.address }}"
+        - "IP:{{ ansible_ssh_host }}"
 
   - name: Generate a Self Signed OpenSSL certificate
     openssl_certificate:

--- a/deploy/ansible/riak.yaml
+++ b/deploy/ansible/riak.yaml
@@ -19,7 +19,7 @@
 
   vars:
     coordinator_name: "{{ groups['riak'][0] }}"
-    coordinator_ip: "{{ hostvars[groups['riak'][0]].ansible_default_ipv4.address }}"
+    coordinator_ip: "{{ hostvars[groups['riak'][0]].ansible_ssh_host }}"
 
     # location of mfn's riak deployment package on local machine
     mfn_riak_deployment_package_dir: "../../riak"
@@ -75,7 +75,7 @@
   - debug:
       msg:
         - inventory_hostname = {{ inventory_hostname }}
-        - ansible_default_ipv4.address = {{ ansible_default_ipv4.address }}
+        - ansible_ssh_host = {{ ansible_ssh_host }}
         - mfn_server_installation_folder = {{ mfn_server_installation_folder }}    # e.g. /opt/mfn
         - coordinator_name = {{ coordinator_name }}
         - coordinator_ip = {{ coordinator_ip }}
@@ -183,7 +183,7 @@
     lineinfile:
       path: "{{ riak_server_config_filepath }}"
       regexp: "^nodename = "
-      line: "nodename = riak@{{ ansible_default_ipv4.address }}"
+      line: "nodename = riak@{{ ansible_ssh_host }}"
 
   - name: configure riak distributed_cookie
     lineinfile:
@@ -195,13 +195,13 @@
     lineinfile:
       path: "{{ riak_server_config_filepath }}"
       regexp: "^listener.protobuf.internal = "
-      line: "listener.protobuf.internal = {{ ansible_default_ipv4.address }}:8087"
+      line: "listener.protobuf.internal = {{ ansible_ssh_host }}:8087"
 
   - name: configure riak http listener
     lineinfile:
       path: "{{ riak_server_config_filepath }}"
       regexp: "^listener.http.internal = "
-      line: "listener.http.internal = {{ ansible_default_ipv4.address }}:8098"
+      line: "listener.http.internal = {{ ansible_ssh_host }}:8098"
 
   - name: configure riak erlang.distribution.port_range.minimum
     lineinfile:
@@ -332,8 +332,8 @@
         #!/bin/sh
         # config file path: {{ riak_server_config_filepath }}
         sudo systemctl start {{ riak_server_service_name }}
-        {{ mfn_server_installation_folder }}/wait-for-it.sh {{ ansible_default_ipv4.address }}:8087 -t 45
-        {{ mfn_server_installation_folder }}/wait-for-it.sh {{ ansible_default_ipv4.address }}:8098 -t 45
+        {{ mfn_server_installation_folder }}/wait-for-it.sh {{ ansible_ssh_host }}:8087 -t 45
+        {{ mfn_server_installation_folder }}/wait-for-it.sh {{ ansible_ssh_host }}:8098 -t 45
 
   - name: create riak stop script
     copy:
@@ -365,7 +365,7 @@
     shell: |
       /usr/sbin/riak-admin cluster status | egrep {{ coordinator_ip }}
     register: alreadypart
-    when: ansible_default_ipv4.address != coordinator_ip
+    when: ansible_ssh_host != coordinator_ip
     failed_when: alreadypart.rc == 1 and alreadypart.stdout != ""
 
   - debug:
@@ -374,13 +374,13 @@
         - already part of cluster cmd stdout = {{ alreadypart.stdout }}
         - already part of cluster cmd stderr = {{ alreadypart.stderr }}
         - already part of cluster cmd rc = {{ alreadypart.rc }}
-    when: ansible_default_ipv4.address != coordinator_ip
+    when: ansible_ssh_host != coordinator_ip
 
   - name: join cluster
     shell: |
       /usr/sbin/riak-admin cluster join riak@{{ coordinator_ip }}
     register: clusterout
-    when: ansible_default_ipv4.address != coordinator_ip and alreadypart.stdout == ""
+    when: ansible_ssh_host != coordinator_ip and alreadypart.stdout == ""
 
   - debug:
       msg:
@@ -388,7 +388,7 @@
         - join cluster cmd stdout = {{ clusterout.stdout }}
         - join cluster cmd stderr = {{ clusterout.stderr }}
         - join cluster rc = {{ clusterout.rc }}
-    when: ansible_default_ipv4.address != coordinator_ip and alreadypart.stdout == ""
+    when: ansible_ssh_host != coordinator_ip and alreadypart.stdout == ""
 
   - name: set mfn_counter_trigger bucket
     shell: |
@@ -451,11 +451,11 @@
       /usr/sbin/riak-admin bucket-type activate maps
 
   - name: wait for riak 8087
-    shell: "{{ mfn_server_installation_folder }}/wait-for-it.sh {{ ansible_default_ipv4.address }}:8087 -t 45"
+    shell: "{{ mfn_server_installation_folder }}/wait-for-it.sh {{ ansible_ssh_host }}:8087 -t 45"
     register: wait_result1
 
   - name: wait for riak 8098
-    shell: "{{ mfn_server_installation_folder }}/wait-for-it.sh {{ ansible_default_ipv4.address }}:8098 -t 45"
+    shell: "{{ mfn_server_installation_folder }}/wait-for-it.sh {{ ansible_ssh_host }}:8098 -t 45"
     register: wait_result2
 
   - name: waiting result
@@ -475,7 +475,7 @@
     shell: |
       /usr/sbin/riak-admin cluster plan
       /usr/sbin/riak-admin cluster commit
-    when: hostvars[groups['riak'][0]].ansible_default_ipv4.address == ansible_default_ipv4.address
+    when: hostvars[groups['riak'][0]].ansible_ssh_host == ansible_ssh_host
 
 #  - name: systemd install and disable mfn-riak service
 #    systemd:

--- a/deploy/ansible/sandbox.yaml
+++ b/deploy/ansible/sandbox.yaml
@@ -15,7 +15,7 @@
 ---
   # run as follows: ansible-playbook -K -e "@settings.json" init_once.yml
   # or as: ./run.sh init_once.yml
-- hosts: all
+- hosts: sandbox
 
   vars:
     sandbox_deployment_package_directory: "../../Sandbox"
@@ -26,13 +26,13 @@
     container_tag: "microfn/sandbox"
     container_java_tag: "microfn/sandbox_java"
     install_dir: "{{ mfn_server_installation_folder }}/sandbox"
-    riak_connect: "{{ hostvars[groups['riak'][0]].ansible_default_ipv4.address }}:8087"
+    riak_connect: "{{ hostvars[groups['riak'][0]].ansible_ssh_host }}:8087"
 
   tasks:
   - debug:
       msg:
       - inventory_hostname = {{ inventory_hostname }}
-      - ansible_default_ipv4.address = {{ ansible_default_ipv4.address }}
+      - ansible_ssh_host = {{ ansible_ssh_host }}
       - mfn_server_installation_folder = {{ mfn_server_installation_folder }}
       - sandbox deployment directory = {{ sandbox_deployment_package_directory }}
       - sandbox deployment package name = {{ sandbox_deployment_package_name }}

--- a/deploy/ansible/triggers_frontend.yaml
+++ b/deploy/ansible/triggers_frontend.yaml
@@ -27,14 +27,14 @@
       triggers_frontend_service_script: "/lib/systemd/system/{{ triggers_frontend_service_name }}.service"
       triggers_frontend_port: "4997"
       triggers_frontend_management_update_interval_sec: "30"
-      management_url: "http://{{ hostvars[groups['management'][0]].ansible_default_ipv4.address }}:{{ management_service_exposed_port }}"
+      management_url: "http://{{ hostvars[groups['management'][0]].ansible_ssh_host }}:{{ management_service_exposed_port }}"
   
     tasks:
   
     - debug:
         msg: 
           - inventory_hostname = {{ inventory_hostname }}
-          - ansible_default_ipv4.address = {{ ansible_default_ipv4.address }}
+          - ansible_ssh_host = {{ ansible_ssh_host }}
           - install_dir = {{ install_dir }}    # e.g. /opt/knix
           - "triggers_frontend package = {{ triggers_frontend_dist }}/{{ triggers_frontend_binary }}"
           - triggers_frontend_port = {{ triggers_frontend_port }}
@@ -114,7 +114,7 @@
         content: |
           #!/bin/sh
           sudo systemctl start {{ triggers_frontend_service_name }}
-          {{ mfn_server_installation_folder }}/wait-for-it.sh {{ ansible_default_ipv4.address }}:{{ triggers_frontend_port }} -t 60
+          {{ mfn_server_installation_folder }}/wait-for-it.sh {{ ansible_ssh_host }}:{{ triggers_frontend_port }} -t 60
   
     - name: create stop script
       copy:
@@ -125,7 +125,7 @@
           sudo systemctl stop {{ triggers_frontend_service_name }}
 
     - name: wait for triggers frontend
-      shell: "{{ mfn_server_installation_folder }}/wait-for-it.sh {{ ansible_default_ipv4.address }}:{{ triggers_frontend_port }} -t 60"
+      shell: "{{ mfn_server_installation_folder }}/wait-for-it.sh {{ ansible_ssh_host }}:{{ triggers_frontend_port }} -t 60"
       register: wait_result
 
     - name: waiting for result

--- a/mfn_sdk/mfn_sdk/workflow.py
+++ b/mfn_sdk/mfn_sdk/workflow.py
@@ -219,7 +219,7 @@ class Workflow(object):
                 time.sleep(sleep)
                 sleep += 1
 
-    def execute_async(self,data,timeout=30):
+    def execute_async(self, data, timeout=30, endpoint=None):
         """ execute a workflow asynchronously and returns an Execution object
 
         The function delivers an event to the frontend and returns an Execution object. Note that the timeout here applies to the delivery of the event, another timeout can be used when fetching the result with the Execution.get(timeout) method
@@ -229,6 +229,8 @@ class Workflow(object):
         :type data: dict()
         :param timeout: time in seconds to wait for the event delivery to complete, otherwise throws ReadTimeout
         :type timeout: int
+        :param endpoint: endpoint url to use
+        :type endpoint: string
         :return: an Execution object to fetch the result
         :rtype: Execution
         :raises requests.exceptions.HTTPError: when the HTTP request to deliver the event fails
@@ -239,8 +241,11 @@ class Workflow(object):
         if self._status != "deployed":
             raise Exception("Workflow not deployed: " + self.name)
 
-        # we are already deployed and have the endpoints stored in self._endpoints
-        url = random.choice(self._endpoints)
+        if endpoint:
+            url = endpoint
+        else:
+            # we are already deployed and have the endpoints stored in self._endpoints
+            url = random.choice(self._endpoints)
 
         try:
             r = self.client._s.post(url,
@@ -255,7 +260,7 @@ class Workflow(object):
         exec_id = r.text
         return Execution(self.client, url, exec_id)
 
-    def execute(self,data,timeout=60, check_duration=False):
+    def execute(self, data, timeout=60, check_duration=False, endpoint=None):
         """ execute a workflow synchronously
 
         The function sends an event to the frontend and waits for the result in the HTTP response
@@ -264,7 +269,11 @@ class Workflow(object):
         :type data: dict()
         :param timeout: time in seconds to wait for the workflow to complete, otherwise throws ReadTimeout
         :type timeout: int
-        :return: the result of the workflow execution
+        :param check_duration: whether to report latency
+        :type check_duration: bool
+        :param endpoint: endpoint url to use
+        :type endpoint: string
+        :return: the result of the workflow execution, or a tuple of the execution result and latency if check_duration is True
         :rtype: dict()
 
         :raises requests.exceptions.HTTPError: when the HTTP request to execute the workflow fails (e.g. 500 ServerError)
@@ -277,8 +286,11 @@ class Workflow(object):
         if self._status != "deployed":
             raise Exception("Workflow not deployed: " + self.name)
 
-        # we are already deployed and have the endpoints stored in self._endpoints
-        url = random.choice(self._endpoints)
+        if endpoint:
+            url = endpoint
+        else:
+            # we are already deployed and have the endpoints stored in self._endpoints
+            url = random.choice(self._endpoints)
         try:
             #postdata = {}
             #postdata["value"] = json.dumps(data)

--- a/tests/mfn_test_utils.py
+++ b/tests/mfn_test_utils.py
@@ -327,13 +327,13 @@ class MFNTest():
         if self._workflow.status == "deployed":
             return self._workflow.endpoints
 
-    def execute(self, message, timeout=None, check_duration=False, async_=False):
+    def execute(self, message, timeout=None, check_duration=False, async_=False, endpoint=None):
         if timeout is None:
             timeout = self._settings["timeout"]
         if async_:
-            return self._workflow.execute_async(message, timeout)
+            return self._workflow.execute_async(message, timeout, endpoint)
         else:
-            return self._workflow.execute(message, timeout, check_duration)
+            return self._workflow.execute(message, timeout, check_duration, endpoint)
 
     def get_workflow_logs(self, num_lines=500):
         data = self._workflow.logs(num_lines=num_lines)


### PR DESCRIPTION
Enable sandbox frontend handle special messages for results of remote executions.

The publication of the result message to the workflow end now gets compared with the client's origin sandbox. If they are different, the special 'remote-result' message is sent to the origin sandbox. If the client origin is the same sandbox, the existing local queue is used as before.

Currently, applies to workflows with addressable functions, where the addressable function is pinned in a sandbox, but other stateless functions may be executed in other sandbox instances. With this PR, the addressable function's results are correctly returned to the sandbox frontend, from which the client can receive the result.

That said, this PR lays the groundwork in handling results of remote executions when in the future workflows are split.

Furthermore, some enhancements to ansible deployments to use the publicly accessible IP address for the target hosts (i.e., the address that the ansible master uses to connect) via the 'ansible_ssh_host' parameter in the inventory. Previous approach was creating problems with VMs with multiple network adapters (e.g., one for default route to access the internet, the other internal host-only network).

For example, the following ansible group will use the IP address of the host knix-1 as the 'ansible_ssh_host', which is then used in the rest of the playbooks.

```ansible
[riak]
knix-1 ansible_ssh_host=$(ping knix-1 -c 1 | head -1 | awk '{print $3}' | awk 'BEGIN {FS="[()]"}; {print $2}')
```

Fixes #88.