### PR TITLE
release 0.9.1

### DIFF
--- a/DataLayerService/pom.xml
+++ b/DataLayerService/pom.xml
@@ -41,7 +41,7 @@
 	<dependency>
 	    <groupId>org.apache.logging.log4j</groupId>
 	    <artifactId>log4j-slf4j-impl</artifactId>
-	    <version>2.13.2</version>
+	    <version>2.15.0</version>
 	</dependency>
   </dependencies>
 

--- a/JavaRequestHandler/pom.xml
+++ b/JavaRequestHandler/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.13.2</version>
+      <version>2.15.0</version>
     </dependency>
     <dependency>
       <groupId>net.sourceforge.argparse4j</groupId>


### PR DESCRIPTION
Bump log4j-* version from 2.13.2 to 2.15.0 in /DataLayerService and /JavaRequestHandler