### PR TITLE
Update log4j to 2.17.1 to address CVE-2021-44832.

### DIFF
--- a/DataLayerService/pom.xml
+++ b/DataLayerService/pom.xml
@@ -31,17 +31,17 @@
 	<dependency>
 	    <groupId>org.apache.logging.log4j</groupId>
 	    <artifactId>log4j-api</artifactId>
-	    <version>2.17.0</version>
+	    <version>2.17.1</version>
 	</dependency>
 	<dependency>
 	    <groupId>org.apache.logging.log4j</groupId>
 	    <artifactId>log4j-core</artifactId>
-	    <version>2.17.0</version>
+	    <version>2.17.1</version>
 	</dependency>
 	<dependency>
 	    <groupId>org.apache.logging.log4j</groupId>
 	    <artifactId>log4j-slf4j-impl</artifactId>
-	    <version>2.17.0</version>
+	    <version>2.17.1</version>
 	</dependency>
   </dependencies>
 


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2021-44832