### PR TITLE
Ansible Makefile doesnt seem to like being in a directory with spaces in the filename

### DIFF
--- a/DataLayerService/Makefile
+++ b/DataLayerService/Makefile
@@ -32,7 +32,7 @@ src/main/java/org/microfunctions/data_layer/DataLayerService.java: \
 	cd ../build_tools/thrift/$(THRIFT_VERSION)/; ./build_thrift.sh; cd -
 	docker run --rm -i --name datalayer-thrift \
 		--user $(UID):$(GID) \
-		-v $(CURDIR):/usr/src/datalayer -w /usr/src/datalayer \
+		-v "$(CURDIR)":/usr/src/datalayer -w /usr/src/datalayer \
 		$(THRIFT_IMAGE_NAME):$(THRIFT_VERSION) \
 		bash -c 'thrift --gen java -out ./src/main/java/ ./thrift/DataLayerMessage.thrift; thrift --gen java -out ./src/main/java/ ./thrift/DataLayerService.thrift'
 	touch src/main/java/org/microfunctions/data_layer/DataLayerService.java
@@ -45,7 +45,7 @@ PythonClient/data_layer: \
 	cd ../build_tools/thrift/$(THRIFT_VERSION)/; ./build_thrift.sh; cd -
 	docker run --rm -i --name datalayer-thrift \
 		--user $(UID):$(GID) \
-		-v $(CURDIR):/usr/src/datalayer -w /usr/src/datalayer \
+		-v "$(CURDIR)":/usr/src/datalayer -w /usr/src/datalayer \
 		$(THRIFT_IMAGE_NAME):$(THRIFT_VERSION) \
 		bash -c 'thrift --gen py -out ./PythonClient ./thrift/DataLayerMessage.thrift; thrift --gen py -out ./PythonClient ./thrift/DataLayerService.thrift'
 
@@ -75,7 +75,7 @@ target/datalayerservice.jar: $(JAVA_SOURCES) \
 	if [ ! -e .m2/repository ]; then mkdir -p .m2/repository; fi
 	docker run --rm -i --name datalayer-maven \
 		--user $(UID):$(GID) \
-		-e HOME=/usr/src/datalayer -v $(CURDIR):/usr/src/datalayer -w /usr/src/datalayer \
+		-e HOME=/usr/src/datalayer -v "$(CURDIR)":/usr/src/datalayer -w /usr/src/datalayer \
 		maven:3.6.1-jdk-8 \
 		mvn -Drevision=$(GIT_REVISION) -Dlibthrift.version=$(MVN_LIBTHRIFT_VERSION) -DargLine="-Duser.home=/tmp" -s /usr/src/datalayer/.m2/settings-docker.xml package
 

--- a/FunctionWorker/Makefile
+++ b/FunctionWorker/Makefile
@@ -27,14 +27,14 @@ $(PYTHON_DATALAYER): ../build_env.mk \
 		../DataLayerService/thrift/DataLayerService.thrift \
 		../build_tools/thrift/$(THRIFT_VERSION)/build_thrift.sh
 	cd ../build_tools/thrift/$(THRIFT_VERSION)/; ./build_thrift.sh; cd -
-	docker run --user $(UID):$(GID) --rm -v $(CURDIR)/..:/root -w /root $(THRIFT_IMAGE_NAME):$(THRIFT_VERSION) bash -c '\
+	docker run --user $(UID):$(GID) --rm -v "$(CURDIR)/..":/root -w /root $(THRIFT_IMAGE_NAME):$(THRIFT_VERSION) bash -c '\
 		thrift --gen py -out FunctionWorker/python/ DataLayerService/thrift/DataLayerMessage.thrift; \
 		thrift --gen py -out FunctionWorker/python/ DataLayerService/thrift/DataLayerService.thrift'
 
 doc/MicroFunctionsAPI.html: $(PYTHON_DATALAYER)
 	docker run --user $(UID):$(GID) --rm -i \
 		--name mfnapi_doc_gen \
-		-v $(CURDIR):/opt/mfnapi \
+		-v "$(CURDIR)":/opt/mfnapi \
 		-w /opt/mfnapi \
 		-e http_proxy \
 		-e https_proxy \

--- a/JavaRequestHandler/Makefile
+++ b/JavaRequestHandler/Makefile
@@ -29,7 +29,7 @@ CLASSFILES=$(shell find target/classes/org/microfunctions/mfnapi/ -type f)
 mfnapi.jar: $(CLASSFILES)
 	docker run --rm --name mfnapijava \
 	--user $(UID):$(GID) \
-	-v $(CURDIR):/usr/src/mfnapijava -w /usr/src/mfnapijava \
+	-v "$(CURDIR)":/usr/src/mfnapijava -w /usr/src/mfnapijava \
 	openjdk:8-jdk-stretch \
 	bash -c 'cd target/classes; jar -cvf mfnapi.jar org/microfunctions/mfnapi/*.class; mv mfnapi.jar ../../'
 
@@ -41,7 +41,7 @@ src/main/java/org/microfunctions/mfnapi/MicroFunctionsAPIService.java: \
 	cp ../FunctionWorker/MicroFunctionsAPI.thrift .
 	docker run --rm -i --name mfnapi-thrift \
 		--user $(UID):$(GID) \
-		-v $(CURDIR):/usr/src/mfnapi -w /usr/src/mfnapi \
+		-v "$(CURDIR)":/usr/src/mfnapi -w /usr/src/mfnapi \
 		$(THRIFT_IMAGE_NAME):$(THRIFT_VERSION) \
 		bash -c 'thrift --gen java -out ./src/main/java/ ./MicroFunctionsAPI.thrift'
 	rm ./MicroFunctionsAPI.thrift
@@ -72,7 +72,7 @@ target/javaworker.jar: $(JAVA_SOURCES) \
 	if [ ! -e .m2/repository ]; then mkdir -p .m2/repository; fi
 	docker run --rm -i --name javaworker \
 		--user $(UID):$(GID) \
-		-e HOME=/usr/src/javaworker -v $(CURDIR):/usr/src/javaworker -w /usr/src/javaworker \
+		-e HOME=/usr/src/javaworker -v "$(CURDIR)":/usr/src/javaworker -w /usr/src/javaworker \
 		maven:3.6.1-jdk-8 \
 		mvn -Drevision=$(GIT_REVISION) -Dlibthrift.version=$(MVN_LIBTHRIFT_VERSION) -DargLine="-Duser.home=/tmp" -s /usr/src/javaworker/.m2/settings-docker.xml -e package; 
 
@@ -83,7 +83,7 @@ target/site/apidocs/index.html: $(JAVA_SOURCES) \
 		.m2/settings-docker.xml
 	docker run --rm -i --name javaworker \
 		--user $(UID):$(GID) \
-		-e HOME=/usr/src/javaworker -v $(CURDIR):/usr/src/javaworker -w /usr/src/javaworker \
+		-e HOME=/usr/src/javaworker -v "$(CURDIR)":/usr/src/javaworker -w /usr/src/javaworker \
 		maven:3.6.1-jdk-8 \
 		mvn -Drevision=$(GIT_REVISION) -Dlibthrift.version=$(MVN_LIBTHRIFT_VERSION) -DargLine="-Duser.home=/tmp" -s /usr/src/javaworker/.m2/settings-docker.xml -e javadoc:javadoc;
 

--- a/LoggingService/fluent-bit-1.2.2/build-fluent-bit.sh
+++ b/LoggingService/fluent-bit-1.2.2/build-fluent-bit.sh
@@ -24,5 +24,5 @@ else
     wget --no-check-certificate https://fluentbit.io/releases/1.2/fluent-bit-1.2.2.tar.gz
 fi
 docker build --build-arg HTTP_PROXY=$HTTP_PROXY --build-arg HTTPS_PROXY=$HTTPS_PROXY --build-arg http_proxy=$http_proxy --build-arg https_proxy=$https_proxy -t fluent-bit-1.2.2-build .
-docker run -i --rm --name fluent-bit-1.2.2-sandbox -v $(pwd):/fluent-bit-build fluent-bit-1.2.2-build /bin/bash -c "cp -r /fluent-bit /fluent-bit-build/. && chmod -R 777 /fluent-bit-build/fluent-bit" 
+docker run -i --rm --name fluent-bit-1.2.2-sandbox -v "$(pwd)":/fluent-bit-build fluent-bit-1.2.2-build /bin/bash -c "cp -r /fluent-bit /fluent-bit-build/. && chmod -R 777 /fluent-bit-build/fluent-bit" 
 ./package-fluent-bit.sh

--- a/ManagementService/Makefile
+++ b/ManagementService/Makefile
@@ -38,7 +38,7 @@ $(THRIFT): ../DataLayerService/thrift/DataLayerMessage.thrift \
 		../build_tools/thrift/$(THRIFT_VERSION)/build_thrift.sh
 	cd ../build_tools/thrift/$(THRIFT_VERSION)/; ./build_thrift.sh; cd -
 	mkdir -p data_layer
-	docker run --user $(UID):$(GID) --rm -v $(CURDIR)/..:/root -w /root $(THRIFT_IMAGE_NAME):$(THRIFT_VERSION) bash -c '\
+	docker run --user $(UID):$(GID) --rm -v "$(CURDIR)/..":/root -w /root $(THRIFT_IMAGE_NAME):$(THRIFT_VERSION) bash -c '\
 		thrift --gen py -out ManagementService/ DataLayerService/thrift/DataLayerMessage.thrift; \
 		thrift --gen py -out ManagementService/ DataLayerService/thrift/DataLayerService.thrift'
 

--- a/Sandbox/Makefile
+++ b/Sandbox/Makefile
@@ -46,7 +46,7 @@ build/SandboxAgent.tar.gz: $(SBASOURCE) $(FWSOURCE)
 build/FunctionWorker.tar.gz: $(FWSOURCE) ../build_env.mk ../build_tools/thrift/$(THRIFT_VERSION)/build_thrift.sh
 	cd ../build_tools/thrift/$(THRIFT_VERSION)/; ./build_thrift.sh; cd -
 	mkdir -p build
-	docker run --user $$(id -u):$$(id -g) --rm -v $$(pwd)/../:/root -w /root $(THRIFT_IMAGE_NAME):$(THRIFT_VERSION) bash -c '\
+	docker run --user $$(id -u):$$(id -g) --rm -v "$$(pwd)/../":/root -w /root $(THRIFT_IMAGE_NAME):$(THRIFT_VERSION) bash -c '\
 		thrift --gen py -out FunctionWorker/python/ DataLayerService/thrift/DataLayerMessage.thrift; \
 		thrift --gen py -out FunctionWorker/python/ DataLayerService/thrift/DataLayerService.thrift;'
 	tar -czf $@ ../FunctionWorker

--- a/Sandbox/frontend/Makefile
+++ b/Sandbox/frontend/Makefile
@@ -30,8 +30,8 @@ datalayermessage: ../../DataLayerService/thrift/DataLayerMessage.thrift ../../bu
 	cd ../../build_tools/thrift/$(THRIFT_VERSION)/; ./build_thrift.sh; cd -
 	docker run --rm -i --name sandbox-thrift \
 		--user $(UID):$(GID) \
-		-v $(CURDIR)/../../DataLayerService:/usr/src/datalayer \
-		-v $(CURDIR):/usr/src/sandbox -w /usr/src/sandbox \
+		-v "$(CURDIR)/../../DataLayerService":/usr/src/datalayer \
+		-v "$(CURDIR)":/usr/src/sandbox -w /usr/src/sandbox \
 		$(THRIFT_IMAGE_NAME):$(THRIFT_VERSION) \
 		bash -c 'thrift --gen go:package_prefix=github.com/knix-microfunctions/knix/Sandbox/frontend/ -out ./ /usr/src/datalayer/thrift/DataLayerMessage.thrift'
 
@@ -39,8 +39,8 @@ datalayerservice: ../../DataLayerService/thrift/DataLayerService.thrift ../../bu
 	cd ../../build_tools/thrift/$(THRIFT_VERSION)/; ./build_thrift.sh; cd -
 	docker run --rm -i --name sandbox-thrift \
 		--user $(UID):$(GID) \
-		-v $(CURDIR)/../../DataLayerService:/usr/src/datalayer \
-		-v $(CURDIR):/usr/src/sandbox -w /usr/src/sandbox \
+		-v "$(CURDIR)/../../DataLayerService":/usr/src/datalayer \
+		-v "$(CURDIR)":/usr/src/sandbox -w /usr/src/sandbox \
 		$(THRIFT_IMAGE_NAME):$(THRIFT_VERSION) \
 		bash -c 'thrift --gen go:package_prefix=github.com/knix-microfunctions/knix/Sandbox/frontend/ -out ./ /usr/src/datalayer/thrift/DataLayerService.thrift'
 
@@ -50,7 +50,7 @@ mfnmessage.go: ../schema/mfnmessage-schema.json
 		--env http_proxy=$(HTTP_PROXY) \
 		--env https_proxy=$(HTTPS_PROXY) \
 		--env XDG_CACHE_HOME=/tmp/.cache \
-		-v $(CURDIR)/../:/usr/src/sandbox \
+		-v "$(CURDIR)/../":/usr/src/sandbox \
 		-w /usr/src/sandbox/frontend \
 		golang:1.13 \
 		bash -c 'go get github.com/a-h/generate/...; schema-generate $^ > $@'
@@ -60,7 +60,7 @@ mfnmessage.go: ../schema/mfnmessage-schema.json
 #		--user $(UID):$(GID) \
 #		--env http_proxy=$(HTTP_PROXY) \
 #		--env https_proxy=$(HTTPS_PROXY) \
-#		-v $(CURDIR)/../:/usr/src/sandbox \
+#		-v "$(CURDIR)/../":/usr/src/sandbox \
 #		-w /usr/src/sandbox/frontend \
 #		golang:1.13 \
 #		bash -c 'go get github.com/a-h/generate/...; schema-generate $^ > $@'
@@ -72,7 +72,7 @@ frontend: mfnmessage.go promstats.go datalayermessage datalayerservice $(SOURCES
 		--env http_proxy=$(HTTP_PROXY) \
 		--env https_proxy=$(HTTPS_PROXY) \
 		--env XDG_CACHE_HOME=/tmp/.cache \
-		-v $(CURDIR):/app \
+		-v "$(CURDIR)":/app \
 		-w /app \
 		golang:1.14 \
 		bash -c 'go mod download; CGO_ENABLED=0 GOOS=linux go build -v -o $@'

--- a/TriggersFrontend/Makefile
+++ b/TriggersFrontend/Makefile
@@ -25,7 +25,7 @@ RUST_SOURCES=$(shell find src/ -type f)
 target/release/TriggersFrontend: $(RUST_SOURCES) Cargo.toml ../build_env.mk
 	docker run --rm --name build_triggers_frontend \
 		--user $(UID):$(GID) \
-		-v $(CURDIR):/code -w /code \
+		-v "$(CURDIR)":/code -w /code \
 		-e http_proxy \
 		-e https_proxy \
 		$(RUST_IMAGE_NAME):$(RUST_VERSION) bash -c 'cargo build --release'

--- a/TriggersFrontend/scripts/run_local_mqttpublisher.sh
+++ b/TriggersFrontend/scripts/run_local_mqttpublisher.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker run -it --rm --network host --name mqttpublisher -v $(pwd):/code -w /code python:3.6 bash -c './mqttpublisher.sh'
+docker run -it --rm --network host --name mqttpublisher -v "$(pwd)":/code -w /code python:3.6 bash -c './mqttpublisher.sh'

--- a/TriggersFrontend/scripts/run_local_mqttsubscriber.sh
+++ b/TriggersFrontend/scripts/run_local_mqttsubscriber.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker run -it --rm --network host --name mqttsubscriber -v $(pwd):/code -w /code python:3.6 bash -c './mqttsubscriber.sh'
+docker run -it --rm --network host --name mqttsubscriber -v "$(pwd)":/code -w /code python:3.6 bash -c './mqttsubscriber.sh'

--- a/TriggersFrontend/scripts/run_local_publisher.sh
+++ b/TriggersFrontend/scripts/run_local_publisher.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker run -it --rm --network host --name rabbitpublisher -v $(pwd):/code -w /code python:3.6 bash -c './publisher.sh'
+docker run -it --rm --network host --name rabbitpublisher -v "$(pwd)":/code -w /code python:3.6 bash -c './publisher.sh'

--- a/TriggersFrontend/scripts/run_local_subscriber.sh
+++ b/TriggersFrontend/scripts/run_local_subscriber.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker run -it --rm --network host --name rabbitsubscriber -v $(pwd):/code -w /code python:3.6 bash -c './subscriber.sh'
+docker run -it --rm --network host --name rabbitsubscriber -v "$(pwd)":/code -w /code python:3.6 bash -c './subscriber.sh'

--- a/deploy/ansible/management.yaml
+++ b/deploy/ansible/management.yaml
@@ -126,7 +126,7 @@
         python3 management_init.py start
         END
         chmod 775 dockerrun.sh
-        docker run -it --rm --network host --ulimit nofile=262144:262144 --env-file .management -v $(pwd):/code -w /code python:3.6 bash -c './dockerrun.sh'
+        docker run -it --rm --network host --ulimit nofile=262144:262144 --env-file .management -v "$(pwd)":/code -w /code python:3.6 bash -c './dockerrun.sh'
         rm dockerrun.sh
         [ "$(docker ps | grep Management)" ] && docker stop Management || true
         [ "$(docker ps -a | grep Management)" ] && docker rm Management || true

--- a/deploy/ansible/sandbox.yaml
+++ b/deploy/ansible/sandbox.yaml
@@ -177,7 +177,7 @@
         python3 available_hosts.py add
         END
         chmod 775 dockerrun.sh
-        docker run -i --rm --network host --ulimit nofile=262144:262144 --env-file .env -v $(pwd):/code -w /code python:3.6 bash -c './dockerrun.sh'
+        docker run -i --rm --network host --ulimit nofile=262144:262144 --env-file .env -v "$(pwd)":/code -w /code python:3.6 bash -c './dockerrun.sh'
         rm dockerrun.sh
         cd -
       mode: '0775'

--- a/redis/Makefile
+++ b/redis/Makefile
@@ -24,7 +24,7 @@ redis-server: Dockerfile_redis_build Makefile
 	echo "Building redis server"
 	mkdir -p redis-server
 	$(call build_image,Dockerfile_redis_build,redis_local_queue)
-	docker run -i --rm -u $$(id -u):$$(id -g) -v $(CURDIR):/temp -w /temp --ulimit nofile=262144:262144 redis_local_queue:$(VERSION) cp /build/redis/src/redis-server redis-server/.
+	docker run -i --rm -u $$(id -u):$$(id -g) -v "$(CURDIR)":/temp -w /temp --ulimit nofile=262144:262144 redis_local_queue:$(VERSION) cp /build/redis/src/redis-server redis-server/.
 	echo "appendonly no" > redis-server/redis_sock.conf
 	echo "save \"\"" >> redis-server/redis_sock.conf
 	echo "port 0" >> redis-server/redis_sock.conf

--- a/riak/Makefile
+++ b/riak/Makefile
@@ -24,7 +24,7 @@ lib/jiffy.tgz: Dockerfile
 	mkdir -p lib
 	echo "Building jiffy"
 	$(call build_image,Dockerfile,riak_libs_build)
-	docker run -i --rm -u $$(id -u):$$(id -g) -v $(CURDIR):/temp -w /temp --ulimit nofile=262144:262144 riak_libs_build:$(VERSION) cp /build/jiffy.tgz ./lib/.
+	docker run -i --rm -u $$(id -u):$$(id -g) -v "$(CURDIR)":/temp -w /temp --ulimit nofile=262144:262144 riak_libs_build:$(VERSION) cp /build/jiffy.tgz ./lib/.
 
 image: Dockerfile-riak \
 		lib/jiffy.tgz \

--- a/riak/src/python_client/run.sh
+++ b/riak/src/python_client/run.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker run -it --rm --network host --ulimit nofile=262144:262144 -v $(pwd):/code -w /code python:3.6 bash -c './dockerrun.sh'
+docker run -it --rm --network host --ulimit nofile=262144:262144 -v "$(pwd)":/code -w /code python:3.6 bash -c './dockerrun.sh'

--- a/tests/triggers_amqp/scripts/run_local_publisher.sh
+++ b/tests/triggers_amqp/scripts/run_local_publisher.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 ./scripts/wait-for-it.sh $(hostname):5672 -t 30
-docker run -d --rm --network host --name rabbitpublisher -v $(pwd):/code -w /code python:3.6 bash -c './scripts/publisher.sh'
+docker run -d --rm --network host --name rabbitpublisher -v "$(pwd)":/code -w /code python:3.6 bash -c './scripts/publisher.sh'

--- a/tests/triggers_amqp/scripts/run_local_subscriber.sh
+++ b/tests/triggers_amqp/scripts/run_local_subscriber.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 ./scripts/wait-for-it.sh $(hostname):5672 -t 30
-docker run -it --rm --network host --name rabbitsubscriber -v $(pwd):/code -w /code python:3.6 bash -c './scripts/subscriber.sh'
+docker run -it --rm --network host --name rabbitsubscriber -v "$(pwd)":/code -w /code python:3.6 bash -c './scripts/subscriber.sh'

--- a/tests/triggers_timer_based_trigger_control/scripts/run_local_publisher.sh
+++ b/tests/triggers_timer_based_trigger_control/scripts/run_local_publisher.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 ./scripts/wait-for-it.sh $(hostname):5672 -t 30
-docker run -d --rm --network host --name rabbitpublisher -v $(pwd):/code -w /code python:3.6 bash -c './scripts/publisher.sh'
+docker run -d --rm --network host --name rabbitpublisher -v "$(pwd)":/code -w /code python:3.6 bash -c './scripts/publisher.sh'

--- a/tests/triggers_timer_based_trigger_control/scripts/run_local_subscriber.sh
+++ b/tests/triggers_timer_based_trigger_control/scripts/run_local_subscriber.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 ./scripts/wait-for-it.sh $(hostname):5672 -t 30
-docker run -it --rm --network host --name rabbitsubscriber -v $(pwd):/code -w /code python:3.6 bash -c './scripts/subscriber.sh'
+docker run -it --rm --network host --name rabbitsubscriber -v "$(pwd)":/code -w /code python:3.6 bash -c './scripts/subscriber.sh'

--- a/tutorials/KNIX-General-Tutorial/resize/README.md
+++ b/tutorials/KNIX-General-Tutorial/resize/README.md
@@ -17,7 +17,7 @@ Python Imaging Library (`pillow`) needs to packaged along with the function code
 cd resize
 
 # install pillow alongside user function
-docker run -it --rm -e https_proxy=${http_proxy} -u $(id -u):$(id -g) -v $(pwd):/temp -w /temp python:3.6 pip3 install pillow -t .
+docker run -it --rm -e https_proxy=${http_proxy} -u $(id -u):$(id -g) -v "$(pwd)":/temp -w /temp python:3.6 pip3 install pillow -t .
 
 # create zip package
 zip -r ../resize.zip .
@@ -42,8 +42,8 @@ python3 request.py leaves.jpg
 
 ```bash
 # install pillow alongside user function
-docker run -it --rm -e https_proxy=${http_proxy} -u $(id -u):$(id -g) -v $(pwd):/temp -w /temp python:3.6 pip3 install pillow -t .
+docker run -it --rm -e https_proxy=${http_proxy} -u $(id -u):$(id -g) -v "$(pwd)":/temp -w /temp python:3.6 pip3 install pillow -t .
 
 # invoke the test script inside a python3.6 docker container
-docker run -it --rm -e https_proxy=${http_proxy} -u $(id -u):$(id -g) -v $(pwd):/temp -w /temp python:3.6 python3 test_local.py
+docker run -it --rm -e https_proxy=${http_proxy} -u $(id -u):$(id -g) -v "$(pwd)":/temp -w /temp python:3.6 python3 test_local.py
 ```

--- a/tutorials/KNIX-General-Tutorial/resize/resize.py
+++ b/tutorials/KNIX-General-Tutorial/resize/resize.py
@@ -18,7 +18,7 @@ from PIL import Image
 # pre-requisite (PIL module should be downloaded in the current folder)
 #   pip3 install pillow -t .
 #         OR
-#   docker run -it --rm -u $(id -u):$(id -g) -v $(pwd):/temp -w /temp python:3.6 pip3 install pillow -t .
+#   docker run -it --rm -u $(id -u):$(id -g) -v "$(pwd)":/temp -w /temp python:3.6 pip3 install pillow -t .
 # zip -r ../resize.zip .
 
 def handle(event, context):

--- a/tutorials/KNIX-General-Tutorial/resize/test_local.py
+++ b/tutorials/KNIX-General-Tutorial/resize/test_local.py
@@ -14,10 +14,10 @@
 
 # Script for locally testing the resize function
 # pre-requisite (PIL module should be downloaded in the current folder)
-# docker run -it --rm -u $(id -u):$(id -g) -v $(pwd):/temp -w /temp python:3.6 pip3 install pillow -t .
+# docker run -it --rm -u $(id -u):$(id -g) -v "$(pwd)":/temp -w /temp python:3.6 pip3 install pillow -t .
 #
 # run as:
-# docker run -it --rm -u $(id -u):$(id -g) -v $(pwd):/temp -w /temp python:3.6 python3 test_local.py
+# docker run -it --rm -u $(id -u):$(id -g) -v "$(pwd)":/temp -w /temp python:3.6 python3 test_local.py
 
 import json, base64
 


### PR DESCRIPTION
when trying to bring up knix with one host (a VM) I got stuck with the following error (actual file path redacted): 

```
$ make
cd ../../riak && make lib/jiffy.tgz && cd -
make[1]: Entering directory '/path/to/Some Directory/that/Contains A Few/spaces/riak'
mkdir -p lib
echo "Building jiffy"
Building jiffy
Container image riak_libs_build:0.9.0-29-g4c8f006-dirty is already up-to-date
docker run -i --rm -u $(id -u):$(id -g) -v /path/to/Some Directory/that/Contains A Few/spaces/riak:/temp -w /temp --ulimit nofile=262144:262144 riak_libs_build:0.9.0-29-g4c8f006-dirty cp /build/jiffy.tgz ./lib/.
docker: invalid reference format: repository name must be lowercase.
See 'docker run --help'.
make[1]: *** [Makefile:27: lib/jiffy.tgz] Error 125
make[1]: Leaving directory '/path/to/Some Directory/that/Contains A Few/spaces/riak'
make: *** [Makefile:50: ../../riak/knix_riak_deployment_package.tar.gz] Error 2

```

I was able to locate the spot where i could enclose the path path (`-v /path/to/Some Directory/that/Contains A Few/spaces/riak:/temp`) in quotes to allow it to handle file paths containing spaces