### PR TITLE
Use a fixed verison of Jiffy in ansible deployments 

### DIFF
--- a/riak/Dockerfile
+++ b/riak/Dockerfile
@@ -54,16 +54,13 @@ RUN set -ex && \
     kerl install R16B02-basho10 /build/erlang/R16B02-basho10 && \
     . /build/erlang/R16B02-basho10/activate
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        rebar
-
 RUN set -ex && \
     . /build/erlang/R16B02-basho10/activate && \
     cd /build && \
     git clone https://github.com/davisp/jiffy.git && \
     cd jiffy && \
-    rebar compile && \
+    git checkout 1.0.9 && \
+    ./rebar compile && \
     cd .. && \
     chmod -R 777 jiffy && \
     tar --exclude .git -cvzf jiffy.tgz jiffy && \

--- a/riak/Dockerfile
+++ b/riak/Dockerfile
@@ -54,12 +54,16 @@ RUN set -ex && \
     kerl install R16B02-basho10 /build/erlang/R16B02-basho10 && \
     . /build/erlang/R16B02-basho10/activate
 
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        rebar
+
 RUN set -ex && \
     . /build/erlang/R16B02-basho10/activate && \
     cd /build && \
     git clone https://github.com/davisp/jiffy.git && \
     cd jiffy && \
-    ./rebar compile && \
+    rebar compile && \
     cd .. && \
     chmod -R 777 jiffy && \
     tar --exclude .git -cvzf jiffy.tgz jiffy && \


### PR DESCRIPTION
In a recent version of jiffy, the rebar script was removed from the repo (probably https://github.com/davisp/jiffy/commit/ec198b19c27a956a8bcfcedbdb9c03f90a50a0d5)

This broke the build process when trying to bring up a new node using the ansible scripts.

This PR checks out an explicit version of jiffy prior to this change, to allow things to still work as written.

