### PR TITLE
Ansible host variable fixes

### DIFF
--- a/deploy/ansible/README.md
+++ b/deploy/ansible/README.md
@@ -124,7 +124,7 @@ Note that for a local installation, your public key should be put into `~/.ssh/a
 
         # For a single remote host installation, the hostname should be added to all groups.
 
-        # For a cluster of hosts (preferably 3 or more), all host names must be added to [riak] group.
+        # For a cluster of hosts (preferably 3 or more), all host names must be added to [riak] group. After each host, add the text "ansible_host=<hostname or IP>"
         # [nginx] and [elasticsearch] group should contain a single host.
         # At least one host should be in [management] and [triggers_frontend] group.
         ```

--- a/deploy/ansible/datalayer.yaml
+++ b/deploy/ansible/datalayer.yaml
@@ -25,16 +25,16 @@
 
     service_name: mfn-datalayer
     service_script: "/lib/systemd/system/{{ service_name }}.service"
-    datalayer_bind: "{{ ansible_ssh_host }}:4998"
+    datalayer_bind: "{{ ansible_host }}:4998"
     riak_connect: "{{ hostvars[groups['riak'][0]].ansible_host }}:8087"
-    all_datalayer_hosts_bind: "{{ groups['all']|map('extract',hostvars)|map(attribute='ansible_ssh_host')|join(':4998,') }}:4998"
+    all_datalayer_hosts_bind: "{{ groups['all']|map('extract',hostvars)|map(attribute='ansible_host')|join(':4998,') }}:4998"
 
   tasks:
 
   - debug:
       msg: 
         - inventory_hostname = {{ inventory_hostname }}
-        - host_ip_address = {{ ansible_ssh_host }}
+        - host_ip_address = {{ ansible_host }}
         - install_dir = {{ install_dir }}    # e.g. /opt/mfn
         - "datalayer package = {{ datalayer_dist }}/{{ datalayer_jar }}"
         - riak_connect = {{ riak_connect }}

--- a/deploy/ansible/datalayer.yaml
+++ b/deploy/ansible/datalayer.yaml
@@ -26,7 +26,7 @@
     service_name: mfn-datalayer
     service_script: "/lib/systemd/system/{{ service_name }}.service"
     datalayer_bind: "{{ ansible_ssh_host }}:4998"
-    riak_connect: "{{ hostvars[groups['riak'][0]].ansible_ssh_host }}:8087"
+    riak_connect: "{{ hostvars[groups['riak'][0]].ansible_host }}:8087"
     all_datalayer_hosts_bind: "{{ groups['all']|map('extract',hostvars)|map(attribute='ansible_ssh_host')|join(':4998,') }}:4998"
 
   tasks:

--- a/deploy/ansible/elasticsearch.yaml
+++ b/deploy/ansible/elasticsearch.yaml
@@ -26,7 +26,7 @@
     es_installer_archive_filename: "{{ es_installer_archive_version }}-linux-x86_64.tar.gz"
 
     es_master_name: "{{ groups['elasticsearch'][0] }}"
-    es_master_ip: "{{ hostvars[groups['elasticsearch'][0]].ansible_ssh_host }}"
+    es_master_ip: "{{ hostvars[groups['elasticsearch'][0]].ansible_host }}"
 
     # Paths on target machine (where elasticsearch will be installed)
     es_server_dir: "{{ mfn_server_installation_folder }}/elasticsearch"
@@ -46,7 +46,7 @@
     es_server_service_path: "/lib/systemd/system/{{ es_server_service_name }}.service"
     es_server_cluster_name: mfn-elasticsearch
 
-    elasticsearch_connect: "{{ hostvars[groups['elasticsearch'][0]].ansible_ssh_host }}:9200"
+    elasticsearch_connect: "{{ hostvars[groups['elasticsearch'][0]].ansible_host }}:9200"
 
   tasks:
   - name: get http_proxy
@@ -70,7 +70,7 @@
   - debug:
       msg: 
         - inventory_hostname = {{ inventory_hostname }}
-        - ansible_ssh_host = {{ ansible_ssh_host }}
+        - ansible_host = {{ ansible_host }}
         - mfn_server_installation_folder = {{ mfn_server_installation_folder }}      # e.g. /opt/mfn
         - es_server_dir = {{ es_server_dir }}                                        # e.g. /opt/mfn/elasticsearch
         - es_server_config_filename = {{ es_server_config_filename }}                # e.g. elasticsearch.yml
@@ -152,11 +152,11 @@
       regexp: "node.name:"
       line: "node.name: {{ inventory_hostname }}"
 
-  - name: "Update {{ es_server_config_filepath }}   network.host: {{ ansible_ssh_host }}"
+  - name: "Update {{ es_server_config_filepath }}   network.host: {{ ansible_host }}"
     lineinfile:
       path: "{{ es_server_config_filepath }}"
       regexp: "network.host:"
-      line: "network.host: {{ ansible_ssh_host }}"
+      line: "network.host: {{ ansible_host }}"
 
   - name: "Update {{ es_server_config_filepath }}   path.data: {{ es_server_dir_data }}"
     lineinfile:
@@ -172,11 +172,11 @@
 
 
   # these could be the names of all the hosts in the cluster
-  - name: "Update {{ es_server_config_filepath }}   discovery.seed_hosts: [\"{{ groups['elasticsearch']|map('extract',hostvars)|map(attribute='ansible_ssh_host')|join('\", \"')}}\"]"
+  - name: "Update {{ es_server_config_filepath }}   discovery.seed_hosts: [\"{{ groups['elasticsearch']|map('extract',hostvars)|map(attribute='ansible_host')|join('\", \"')}}\"]"
     lineinfile:
       path: "{{ es_server_config_filepath }}"
       regexp: "discovery.seed_hosts:"
-      line: "discovery.seed_hosts: [\"{{ groups['elasticsearch']|map('extract',hostvars)|map(attribute='ansible_ssh_host')|join('\", \"')}}\"]"
+      line: "discovery.seed_hosts: [\"{{ groups['elasticsearch']|map('extract',hostvars)|map(attribute='ansible_host')|join('\", \"')}}\"]"
   
   # always points to the master node
   - name: "Update {{ es_server_config_filepath }}   cluster.initial_master_nodes: [\"{{ es_master_name }}\"]"
@@ -272,7 +272,7 @@
         #config file path: {{ es_server_dir_config }}
         cd {{ es_server_dir }}
         sudo systemctl start {{ es_server_service_name }}
-        {{ mfn_server_installation_folder }}/wait-for-it.sh {{ ansible_ssh_host }}:9200 -t 60
+        {{ mfn_server_installation_folder }}/wait-for-it.sh {{ ansible_host }}:9200 -t 60
         ./esconfig.sh
         cd -
 
@@ -296,7 +296,7 @@
         sudo rm -rf logs/*
 
   - name: wait for elasticsearch
-    shell: "{{ mfn_server_installation_folder }}/wait-for-it.sh {{ ansible_ssh_host }}:9200 -t 180"
+    shell: "{{ mfn_server_installation_folder }}/wait-for-it.sh {{ ansible_host }}:9200 -t 180"
     register: wait_result
 
   - name: waiting result
@@ -315,11 +315,11 @@
       HTTP_PROXY: "{{ http_proxy }}"
       HTTPS_PROXY: "{{ https_proxy }}"
     register: esconfig_command
-    when: ansible_ssh_host == es_master_ip
+    when: ansible_host == es_master_ip
   
   - debug:
       var: esconfig_command.stdout
-    when: ansible_ssh_host == es_master_ip
+    when: ansible_host == es_master_ip
 
 #  - name: systemd install and disable mfn-elasticsearch service
 #    systemd:

--- a/deploy/ansible/fluentbit.yaml
+++ b/deploy/ansible/fluentbit.yaml
@@ -21,7 +21,7 @@
     fluentbit_dir: "../../LoggingService/fluent-bit"
     install_dir: "{{ mfn_server_installation_folder }}/fluentbit"
     conf_dir: "{{ install_dir }}/conf"
-    elasticsearch_host: "{{ hostvars[groups['elasticsearch'][0]].ansible_ssh_host }}"
+    elasticsearch_host: "{{ hostvars[groups['elasticsearch'][0]].ansible_host }}"
     elasticsearch_port: 9200
     service_name: mfn-fluentbit
     service_script: "/lib/systemd/system/{{ service_name }}.service"
@@ -59,7 +59,7 @@
   - debug:
       msg: 
       - inventory_hostname = {{ inventory_hostname }}
-      - ansible_ssh_host = {{ ansible_ssh_host }}
+      - ansible_host = {{ ansible_host }}
       - mfn_server_installation_folder = {{ mfn_server_installation_folder }}    # e.g. /opt/mfn
       - install_dir = {{ install_dir }}
       - conf_dir = {{ conf_dir }}

--- a/deploy/ansible/init_once.yaml
+++ b/deploy/ansible/init_once.yaml
@@ -35,7 +35,7 @@
   - debug:
       msg:
       - inventory_hostname = {{ inventory_hostname }}
-      - ansible_ssh_host = {{ ansible_ssh_host }}
+      - ansible_host = {{ ansible_host }}
       - mfn_server_installation_folder = {{ mfn_server_installation_folder }}
       - proxy settings files = ./proxy/
       - http_proxy = {{ http_proxy }}
@@ -78,7 +78,7 @@
     lineinfile:
       path: "/etc/hosts"
       insertafter: EOF
-      line: "{{ ansible_ssh_host }} {{ inventory_hostname }} {{ inventory_hostname }}"
+      line: "{{ ansible_host }} {{ inventory_hostname }} {{ inventory_hostname }}"
 
   - name: ensure docker is at the latest version
     apt: name=docker-ce update_cache=yes

--- a/deploy/ansible/knix-mfn.nginx.conf.j2
+++ b/deploy/ansible/knix-mfn.nginx.conf.j2
@@ -1,6 +1,6 @@
 upstream knix_management {
 {% for host in groups['management'] %}
-        server {{ hostvars[host].ansible_ssh_host }}:{{ management_service_exposed_port }};
+        server {{ hostvars[host].ansible_host }}:{{ management_service_exposed_port }};
 {% endfor %}
 }
 

--- a/deploy/ansible/management.yaml
+++ b/deploy/ansible/management.yaml
@@ -23,10 +23,10 @@
     management_archive_filename: management_deployment_package.tar.gz
 
     install_dir: "{{ mfn_server_installation_folder }}/management"
-    datalayer_connect: "{{ ansible_ssh_host }}:4998" # same host
-    elasticsearch_connect: "{{ hostvars[groups['elasticsearch'][0]].ansible_ssh_host }}:9200"
+    datalayer_connect: "{{ ansible_host }}:4998" # same host
+    elasticsearch_connect: "{{ hostvars[groups['elasticsearch'][0]].ansible_host }}:9200"
     nginx_http_listen_port: "{{ nginx_http_listen_port }}"
-    nginx_connect: "{{ hostvars[groups['nginx'][0]].ansible_ssh_host }}:{{ nginx_http_listen_port }}"
+    nginx_connect: "{{ hostvars[groups['nginx'][0]].ansible_host }}:{{ nginx_http_listen_port }}"
 
   tasks:
 
@@ -50,7 +50,7 @@
   - debug:
       msg:
       - inventory_hostname = {{ inventory_hostname }}
-      - ansible_ssh_host = {{ ansible_ssh_host }}
+      - ansible_host = {{ ansible_host }}
       - mfn_server_installation_folder = {{ mfn_server_installation_folder }}    # e.g. /opt/mfn
       - management_service_dir = {{ management_service_dir }}
       - management_archive_filename = {{ management_archive_filename }}

--- a/deploy/ansible/nginx.yaml
+++ b/deploy/ansible/nginx.yaml
@@ -49,7 +49,7 @@
   - debug:
       msg:
         - inventory_hostname = {{ inventory_hostname }}
-        - ansible_ssh_host = {{ ansible_ssh_host }}
+        - ansible_host = {{ ansible_host }}
         - mfn_server_installation_folder = {{ mfn_server_installation_folder }}    # e.g. /opt/mfn
         - install_dir = {{ install_dir }}
         - frontend_http_listen_port = {{ frontend_http_listen_port }}
@@ -121,7 +121,7 @@
         - "DNS:{{ ansible_fqdn }}"
         - "DNS:{{ ansible_hostname }}"
         - "{{ inventory_hostname | ipaddr() | ternary( 'IP:', 'DNS:') }}{{ inventory_hostname }}"
-        - "IP:{{ ansible_ssh_host }}"
+        - "IP:{{ ansible_host }}"
 
   - name: Generate a Self Signed OpenSSL certificate
     openssl_certificate:

--- a/deploy/ansible/riak.yaml
+++ b/deploy/ansible/riak.yaml
@@ -365,7 +365,7 @@
     shell: |
       /usr/sbin/riak-admin cluster status | egrep {{ coordinator_ip }}
     register: alreadypart
-    when: ansible_hostcoordinator_ip
+    when: ansible_host != coordinator_ip
     failed_when: alreadypart.rc == 1 and alreadypart.stdout != ""
 
   - debug:

--- a/deploy/ansible/riak.yaml
+++ b/deploy/ansible/riak.yaml
@@ -75,7 +75,7 @@
   - debug:
       msg:
         - inventory_hostname = {{ inventory_hostname }}
-        - ansible_ssh_host = {{ ansible_ssh_host }}
+        - ansible_host = {{ ansible_host }}
         - mfn_server_installation_folder = {{ mfn_server_installation_folder }}    # e.g. /opt/mfn
         - coordinator_name = {{ coordinator_name }}
         - coordinator_ip = {{ coordinator_ip }}
@@ -183,7 +183,7 @@
     lineinfile:
       path: "{{ riak_server_config_filepath }}"
       regexp: "^nodename = "
-      line: "nodename = riak@{{ ansible_ssh_host }}"
+      line: "nodename = riak@{{ ansible_host }}"
 
   - name: configure riak distributed_cookie
     lineinfile:
@@ -195,13 +195,13 @@
     lineinfile:
       path: "{{ riak_server_config_filepath }}"
       regexp: "^listener.protobuf.internal = "
-      line: "listener.protobuf.internal = {{ ansible_ssh_host }}:8087"
+      line: "listener.protobuf.internal = {{ ansible_host }}:8087"
 
   - name: configure riak http listener
     lineinfile:
       path: "{{ riak_server_config_filepath }}"
       regexp: "^listener.http.internal = "
-      line: "listener.http.internal = {{ ansible_ssh_host }}:8098"
+      line: "listener.http.internal = {{ ansible_host }}:8098"
 
   - name: configure riak erlang.distribution.port_range.minimum
     lineinfile:
@@ -332,8 +332,8 @@
         #!/bin/sh
         # config file path: {{ riak_server_config_filepath }}
         sudo systemctl start {{ riak_server_service_name }}
-        {{ mfn_server_installation_folder }}/wait-for-it.sh {{ ansible_ssh_host }}:8087 -t 45
-        {{ mfn_server_installation_folder }}/wait-for-it.sh {{ ansible_ssh_host }}:8098 -t 45
+        {{ mfn_server_installation_folder }}/wait-for-it.sh {{ ansible_host }}:8087 -t 45
+        {{ mfn_server_installation_folder }}/wait-for-it.sh {{ ansible_host }}:8098 -t 45
 
   - name: create riak stop script
     copy:
@@ -365,7 +365,7 @@
     shell: |
       /usr/sbin/riak-admin cluster status | egrep {{ coordinator_ip }}
     register: alreadypart
-    when: ansible_ssh_host != coordinator_ip
+    when: ansible_hostcoordinator_ip
     failed_when: alreadypart.rc == 1 and alreadypart.stdout != ""
 
   - debug:
@@ -374,13 +374,13 @@
         - already part of cluster cmd stdout = {{ alreadypart.stdout }}
         - already part of cluster cmd stderr = {{ alreadypart.stderr }}
         - already part of cluster cmd rc = {{ alreadypart.rc }}
-    when: ansible_ssh_host != coordinator_ip
+    when: ansible_host != coordinator_ip
 
   - name: join cluster
     shell: |
       /usr/sbin/riak-admin cluster join riak@{{ coordinator_ip }}
     register: clusterout
-    when: ansible_ssh_host != coordinator_ip and alreadypart.stdout == ""
+    when: ansible_host != coordinator_ip and alreadypart.stdout == ""
 
   - debug:
       msg:
@@ -388,7 +388,7 @@
         - join cluster cmd stdout = {{ clusterout.stdout }}
         - join cluster cmd stderr = {{ clusterout.stderr }}
         - join cluster rc = {{ clusterout.rc }}
-    when: ansible_ssh_host != coordinator_ip and alreadypart.stdout == ""
+    when: ansible_host != coordinator_ip and alreadypart.stdout == ""
 
   - name: set mfn_counter_trigger bucket
     shell: |
@@ -451,11 +451,11 @@
       /usr/sbin/riak-admin bucket-type activate maps
 
   - name: wait for riak 8087
-    shell: "{{ mfn_server_installation_folder }}/wait-for-it.sh {{ ansible_ssh_host }}:8087 -t 45"
+    shell: "{{ mfn_server_installation_folder }}/wait-for-it.sh {{ ansible_host }}:8087 -t 45"
     register: wait_result1
 
   - name: wait for riak 8098
-    shell: "{{ mfn_server_installation_folder }}/wait-for-it.sh {{ ansible_ssh_host }}:8098 -t 45"
+    shell: "{{ mfn_server_installation_folder }}/wait-for-it.sh {{ ansible_host }}:8098 -t 45"
     register: wait_result2
 
   - name: waiting result
@@ -475,7 +475,7 @@
     shell: |
       /usr/sbin/riak-admin cluster plan
       /usr/sbin/riak-admin cluster commit
-    when: hostvars[groups['riak'][0]].ansible_ssh_host == ansible_ssh_host
+    when: hostvars[groups['riak'][0]].ansible_host == ansible_host
 
 #  - name: systemd install and disable mfn-riak service
 #    systemd:

--- a/deploy/ansible/riak.yaml
+++ b/deploy/ansible/riak.yaml
@@ -19,7 +19,7 @@
 
   vars:
     coordinator_name: "{{ groups['riak'][0] }}"
-    coordinator_ip: "{{ hostvars[groups['riak'][0]].ansible_ssh_host }}"
+    coordinator_ip: "{{ hostvars[groups['riak'][0]].ansible_host }}"
 
     # location of mfn's riak deployment package on local machine
     mfn_riak_deployment_package_dir: "../../riak"

--- a/deploy/ansible/sandbox.yaml
+++ b/deploy/ansible/sandbox.yaml
@@ -32,7 +32,7 @@
   - debug:
       msg:
       - inventory_hostname = {{ inventory_hostname }}
-      - ansible_ssh_host = {{ ansible_ssh_host }}
+      - ansible_host = {{ ansible_host }}
       - mfn_server_installation_folder = {{ mfn_server_installation_folder }}
       - sandbox deployment directory = {{ sandbox_deployment_package_directory }}
       - sandbox deployment package name = {{ sandbox_deployment_package_name }}

--- a/deploy/ansible/sandbox.yaml
+++ b/deploy/ansible/sandbox.yaml
@@ -26,7 +26,7 @@
     container_tag: "microfn/sandbox"
     container_java_tag: "microfn/sandbox_java"
     install_dir: "{{ mfn_server_installation_folder }}/sandbox"
-    riak_connect: "{{ hostvars[groups['riak'][0]].ansible_ssh_host }}:8087"
+    riak_connect: "{{ hostvars[groups['riak'][0]].ansible_host }}:8087"
 
   tasks:
   - debug:

--- a/deploy/ansible/triggers_frontend.yaml
+++ b/deploy/ansible/triggers_frontend.yaml
@@ -27,14 +27,14 @@
       triggers_frontend_service_script: "/lib/systemd/system/{{ triggers_frontend_service_name }}.service"
       triggers_frontend_port: "4997"
       triggers_frontend_management_update_interval_sec: "30"
-      management_url: "http://{{ hostvars[groups['management'][0]].ansible_ssh_host }}:{{ management_service_exposed_port }}"
+      management_url: "http://{{ hostvars[groups['management'][0]].ansible_host }}:{{ management_service_exposed_port }}"
   
     tasks:
   
     - debug:
         msg: 
           - inventory_hostname = {{ inventory_hostname }}
-          - ansible_ssh_host = {{ ansible_ssh_host }}
+          - ansible_host = {{ ansible_host }}
           - install_dir = {{ install_dir }}    # e.g. /opt/knix
           - "triggers_frontend package = {{ triggers_frontend_dist }}/{{ triggers_frontend_binary }}"
           - triggers_frontend_port = {{ triggers_frontend_port }}
@@ -114,7 +114,7 @@
         content: |
           #!/bin/sh
           sudo systemctl start {{ triggers_frontend_service_name }}
-          {{ mfn_server_installation_folder }}/wait-for-it.sh {{ ansible_ssh_host }}:{{ triggers_frontend_port }} -t 60
+          {{ mfn_server_installation_folder }}/wait-for-it.sh {{ ansible_host }}:{{ triggers_frontend_port }} -t 60
   
     - name: create stop script
       copy:
@@ -125,7 +125,7 @@
           sudo systemctl stop {{ triggers_frontend_service_name }}
 
     - name: wait for triggers frontend
-      shell: "{{ mfn_server_installation_folder }}/wait-for-it.sh {{ ansible_ssh_host }}:{{ triggers_frontend_port }} -t 60"
+      shell: "{{ mfn_server_installation_folder }}/wait-for-it.sh {{ ansible_host }}:{{ triggers_frontend_port }} -t 60"
       register: wait_result
 
     - name: waiting for result


### PR DESCRIPTION
This PR addresses the issue identified in https://github.com/knix-microfunctions/knix/issues/161 (and PR #162 which was accidentally closed as i was reorganizing git branches). It achieves this by updating some of the ansible configs to use a newer variable name to access the ssh hostname.

Approach

While I initially defaulted to using `ansible_default_ipv4.address` - it seems as though that created problems in the past, so I just stuck with using ansible_host  and ensuring this is defined in `inventory.cfg`

Disclosure: I approached this fix with a largely automated find-and-replace strategy

Testing and possible drawbacks to this PR

I am able to get KNIX to install with this change (will be trying to run things soon). This changeset may have changed slightly more things than necessary but it shouldn't be too bad

fixes https://github.com/knix-microfunctions/knix/issues/161